### PR TITLE
Integration

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,52 @@
+# Media Library Reader -- Build Instructions
+
+Instructions for working with the medialibrary source code.
+
+## Download Source Code
+
+```
+$ cd code
+$ git clone https://github.com/cjcodeproj/medialibrary.git
+```
+
+## Building
+
+Assuming a normal Python 3 environment with setuptools and build modules installed:
+
+```
+$ cd medialibrary
+$ python -m build 
+```
+
+The build will generate a dist/ directory with a .tar.gz file and a .whl file, suitable
+for installing.  When ready to install, just use the PIP command as documented in the
+README.md file.
+
+
+## Unit Tests
+
+Unit tests can be run as follows:
+```
+$ cd medialibrary
+$ PYTHONPATH=src/ python -m unittest
+```
+
+
+## Code Cleanliness
+
+### Source Module
+
+All code is checked with pycodestyle and pylint before committed.
+
+```
+$ cd medialibrary/src
+$ pycodestyle media
+$ pylint media
+```
+
+### Unit Tests
+```
+$ cd medialibrary
+$ pycodestyle test
+$ PYTHONPATH=src/ pylint test
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-39](https://github.com/cjcodeproj/medialibrary/issues/39) Code to read physical media data
  - [medialibrary-40](https://github.com/cjcodeproj/medialibrary/issues/40) Simple tool for validating movie data
  - [medialibrary-38](https://github.com/cjcodeproj/medialibrary/issues/38) POC tool to graph time distribution
  - [medialibrary-35](https://github.com/cjcodeproj/medialibrary/issues/35) Exceptions for some missing data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-33](https://github.com/cjcodeproj/medialibrary/issues/33) Issue with Movie class when catalog data is incomplete.
  - [medialibrary-22](https://github.com/cjcodeproj/medialibrary/issues/22) Slight flaw with title search code
  - [medialibrary-29](https://github.com/cjcodeproj/medialibrary/issues/29) Create technical/runtime code
  - [medialibrary-25](https://github.com/cjcodeproj/medialibrary/issues/25) Random sample output in POC tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-21](https://github.com/cjcodeproj/medialibrary/issues/21) Reevaluate file loading code
  - [medialibrary-20](https://github.com/cjcodeproj/medialibrary/issues/20) Improvements to POC tools
  - [medialibrary-17](https://github.com/cjcodeproj/medialibrary/issues/17) Setup object hashes
  - [medialibrary-19](https://github.com/cjcodeproj/medialibrary/issues/19) Update code for Character Names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-35](https://github.com/cjcodeproj/medialibrary/issues/35) Exceptions for some missing data
  - [medialibrary-32](https://github.com/cjcodeproj/medialibrary/issues/32) Unit tests
  - [medialibrary-33](https://github.com/cjcodeproj/medialibrary/issues/33) Issue with Movie class when catalog data is incomplete.
  - [medialibrary-22](https://github.com/cjcodeproj/medialibrary/issues/22) Slight flaw with title search code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-38](https://github.com/cjcodeproj/medialibrary/issues/38) POC tool to graph time distribution
  - [medialibrary-35](https://github.com/cjcodeproj/medialibrary/issues/35) Exceptions for some missing data
  - [medialibrary-32](https://github.com/cjcodeproj/medialibrary/issues/32) Unit tests
  - [medialibrary-33](https://github.com/cjcodeproj/medialibrary/issues/33) Issue with Movie class when catalog data is incomplete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 medialibrary CHANGELOG
 ======================
 
-## CURRENT
+## RELEASE 0.1.5
+ - [medialibrary-72](https://github.com/cjcodeproj/medialibrary/issues/72) Prep work for first release to PyPi (0.1.5)
  - [medialibrary-50](https://github.com/cjcodeproj/medialibrary/issues/50) More metadata in the pyproject.toml
  - [medialibrary-65](https://github.com/cjcodeproj/medialibrary/issues/65) All code files should have copyright headers
  - [medialibrary-68](https://github.com/cjcodeproj/medialibrary/issues/68) Command line tool genrebreakdown has same bad title dictionary index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-40](https://github.com/cjcodeproj/medialibrary/issues/40) Simple tool for validating movie data
  - [medialibrary-38](https://github.com/cjcodeproj/medialibrary/issues/38) POC tool to graph time distribution
  - [medialibrary-35](https://github.com/cjcodeproj/medialibrary/issues/35) Exceptions for some missing data
  - [medialibrary-32](https://github.com/cjcodeproj/medialibrary/issues/32) Unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-50](https://github.com/cjcodeproj/medialibrary/issues/50) More metadata in the pyproject.toml
+ - [medialibrary-65](https://github.com/cjcodeproj/medialibrary/issues/65) All code files should have copyright headers
+ - [medialibrary-68](https://github.com/cjcodeproj/medialibrary/issues/68) Command line tool genrebreakdown has same bad title dictionary index
+ - [medialibrary-67](https://github.com/cjcodeproj/medialibrary/issues/67) Page break between movie entries
+ - [medialibrary-66](https://github.com/cjcodeproj/medialibrary/issues/66) POC tool castlist doesn't handle duplicate titles properly
+ - [medialibrary-46](https://github.com/cjcodeproj/medialibrary/issues/46) Command line tools should have stats option
+ - [medialibrary-63](https://github.com/cjcodeproj/medialibrary/issues/63) Create object code to handle "art" proper noun
+ - [medialibrary-62](https://github.com/cjcodeproj/medialibrary/issues/62) First PyPi test
+ - [medialibrary-56](https://github.com/cjcodeproj/medialibrary/issues/56) File loader ignored Blu-Ray 3d movies
+ - [medialibrary-45](https://github.com/cjcodeproj/medialibrary/issues/45) XML elements without text may cause an error when stripped
+ - [medialibrary-18](https://github.com/cjcodeproj/medialibrary/issues/18) Proper Noun name sorting mixes up when there is no family name
  - [medialibrary-43](https://github.com/cjcodeproj/medialibrary/issues/43) Reign in the README.md file
  - [medialibrary-39](https://github.com/cjcodeproj/medialibrary/issues/39) Code to read physical media data
  - [medialibrary-40](https://github.com/cjcodeproj/medialibrary/issues/40) Simple tool for validating movie data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-22](https://github.com/cjcodeproj/medialibrary/issues/22) Slight flaw with title search code
  - [medialibrary-29](https://github.com/cjcodeproj/medialibrary/issues/29) Create technical/runtime code
  - [medialibrary-25](https://github.com/cjcodeproj/medialibrary/issues/25) Random sample output in POC tools
  - [medialibrary-24](https://github.com/cjcodeproj/medialibrary/issues/24) Provide breakdown of film genres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-24](https://github.com/cjcodeproj/medialibrary/issues/24) Provide breakdown of film genres
  - [medialibrary-21](https://github.com/cjcodeproj/medialibrary/issues/21) Reevaluate file loading code
  - [medialibrary-20](https://github.com/cjcodeproj/medialibrary/issues/20) Improvements to POC tools
  - [medialibrary-17](https://github.com/cjcodeproj/medialibrary/issues/17) Setup object hashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-32](https://github.com/cjcodeproj/medialibrary/issues/32) Unit tests
  - [medialibrary-33](https://github.com/cjcodeproj/medialibrary/issues/33) Issue with Movie class when catalog data is incomplete.
  - [medialibrary-22](https://github.com/cjcodeproj/medialibrary/issues/22) Slight flaw with title search code
  - [medialibrary-29](https://github.com/cjcodeproj/medialibrary/issues/29) Create technical/runtime code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-25](https://github.com/cjcodeproj/medialibrary/issues/25) Random sample output in POC tools
  - [medialibrary-24](https://github.com/cjcodeproj/medialibrary/issues/24) Provide breakdown of film genres
  - [medialibrary-21](https://github.com/cjcodeproj/medialibrary/issues/21) Reevaluate file loading code
  - [medialibrary-20](https://github.com/cjcodeproj/medialibrary/issues/20) Improvements to POC tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-29](https://github.com/cjcodeproj/medialibrary/issues/29) Create technical/runtime code
  - [medialibrary-25](https://github.com/cjcodeproj/medialibrary/issues/25) Random sample output in POC tools
  - [medialibrary-24](https://github.com/cjcodeproj/medialibrary/issues/24) Provide breakdown of film genres
  - [medialibrary-21](https://github.com/cjcodeproj/medialibrary/issues/21) Reevaluate file loading code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-43](https://github.com/cjcodeproj/medialibrary/issues/43) Reign in the README.md file
  - [medialibrary-39](https://github.com/cjcodeproj/medialibrary/issues/39) Code to read physical media data
  - [medialibrary-40](https://github.com/cjcodeproj/medialibrary/issues/40) Simple tool for validating movie data
  - [medialibrary-38](https://github.com/cjcodeproj/medialibrary/issues/38) POC tool to graph time distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ medialibrary CHANGELOG
 ======================
 
 ## CURRENT
+ - [medialibrary-20](https://github.com/cjcodeproj/medialibrary/issues/20) Improvements to POC tools
  - [medialibrary-17](https://github.com/cjcodeproj/medialibrary/issues/17) Setup object hashes
  - [medialibrary-19](https://github.com/cjcodeproj/medialibrary/issues/19) Update code for Character Names
  - [medialibrary-16](https://github.com/cjcodeproj/medialibrary/issues/16) FilenameMatches regex pattern is incorrect

--- a/README.md
+++ b/README.md
@@ -132,6 +132,36 @@ Robert De Niro                 Killing Season                 Benjamin Ford
 
 The easiest way to test is to download a copy of the vtmedia-schema repo and use the examples there.
 
+## Python Shell Interface (Beta)
+
+Pulling data using the Python Shell.
+
+```
+$ python
+Python 3.9.7 (default, Sep  3 2021, 12:15:38) 
+[GCC 10.2.0] on sunos5
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import media.fileops.loader
+>>> import media.fileops.repo
+>>> r=media.fileops.repo.Repo('/home/user/xml/vtmedia-schema/examples/movies')
+>>> r.scan()
+>>> loader = media.fileops.loader.Loader()
+>>> dev_list = loader.load_media(r)
+>>> print(dev_list[0].contents[0].title)
+Killing Season
+>>> print(dev_list[0].contents[1].title)
+Red Lights
+>>> print(dev_list[1].contents[0].title)
+All The President's Men
+>>> print(dev_list[2].contents[0].title)
+Unstoppable
+>>> print(dev_list[3].contents[0].title)
+Road House 2: Last Call
+>>> print(dev_list[4].contents[0].title)
+The Last Starfighter
+>>> 
+```
+
 ## Building
 
 Assuming a normal Python 3 environment with setuptools and build modules installed:

--- a/README.md
+++ b/README.md
@@ -1,247 +1,17 @@
-# Media Schema Reader
+# Media Library Reader
 
-Code library for reading XML files using to the vtmedia schema.
+The `medialibrary` module is a Python module for reading XML files containing entertainment media
+data adhering to the vtmedia schema.
 
-The vtmedia schema is an XML schema for recording data on physical copies of media like CDs, or 
-DVDs, and their contents.
 
-## Executables/Demos
+| Repository | Purpose |
+| --- | --- |
+| [vtmedia-schema](https://github.com/cjcodeproj/vtmedia-schema) | Schema and XML validation for media data |
+| [mediadata](https://github.com/cjcodeproj/mediadata) | A large dataset of sample media/movie data |
 
-Thre are eight demonstration proof of concept executables in the library.
 
-```
-media.tools.movies.list
-media.tools.movies.show
-media.tools.movies.namelist
-media.tools.movies.keywordlist
-media.tools.movies.castlist
-media.tools.movies.genrebreakdown
-media.tools.movies.timebuckets
-media.tools.movies.debuglist
-```
-
-To run these tools use.
-
-```
-$ export MEDIAPATH=(path_to_xml_directory_structure)
-$ python -m media.tools.movies.list
-$ python -m media.tools.movies.show
-$ python -m media.tools.movies.namelist
-$ python -m media.tools.movies.keywordlist
-$ python -m media.tools.movies.castlist
-$ python -m media.tools.movies.genrebreakdown
-$ python -m media.tools.movies.timebuckets
-$ python -m media.tools.movies.debuglist
-```
-
-```
-$ python -m media.tools.movies.list
-Title                                              Year Genre                                             
-================================================== ==== ==================================================
-2010                                               1984 [FICTION] Sci-Fi "Space Exploration Adventure"    
-All The President's Men                            1976 [FICTION] Drama/Mystery "Newspaper Mystery"       
-Contact                                            1997 [FICTION] Sci-Fi/Drama "Alien Contact"            
-Death Proof                                        2017 [FICTION] Horror/Thriller "Car Action"            
-...
-```
-
-```
-$ python -m media.tools.movies.show
-...
-All The President's Men                                               (1976)
-============================================================================
-[FICTION] Drama/Mystery "Newspaper Mystery"
-(based on a true story, based on a book)
-
-Director: Alan Pakula
-Cinemaphotographer: Gordon Willis
-Cast: Dustin Hoffman, Robert Redford, Jack Warden, Martin Balsam, Hal
-      Holbrook, Jason Robards, Jane Alexander
-
-Plot
-Two news reporters investigate the Watergate burglary and discover a
-conspiracy leading all the way to the President Of The United States.
-
-Keywords:
- Charles Colson, CIA, Clark McGregor, Department Of Justice, Donald
- Segretti, FBI, Hugh Sloan, investigative journalism, journalism, Ken
- Clawson, Library Of Congress, Mark Felt, newspaper, parking garage, Richard
- Nixon, Richard Nixon, scandal, taxi cabs, The Washington Post, Watergate
- Conspiracy, Watergate Hotel, White House
-
-...
-```
-
-```
-python -m media.tools.movies.namelist
-Family Name          Given Name      Job Role             Title
-==================== =============== ==================== =========================
-Abroms               Edward          Editor               The Sugarland Express
-Alberti              Maryse          Cinemaphotographer   Enron: The Smartest Guys In The Room
-Albertson            Sean            Editor               Killing Season
-Alden Robinson       Phil            Director             Sneakers
-Alden Robinson       Phil            Writer               Sneakers
-Alexander            Jane            Cast                 All The President's Men
-Apple                Cathering       Editor               Onward
-Ashton               John            Cast                 Midnight Run
-...
-```
-
-```
-$ python -m media.tools.movies.keywordlist
-Keyword                                       Title
-============================================= =========================
-properNoun/place/7-Eleven                     Wargames
-generic/accountant                            Midnight Run
-generic/affair                                Blood Simple
-generic/air duct                              The Great Escape
-properNoun/entity/Air Force                   Wargames
-generic/alcohol                               Death Proof
-generic/alien contact                         Contact
-generic/alien invasion                        The Last Starfighter
-generic/aliens                                The Last Starfighter
-properNoun/thing/Allure                       Death Proof
-properNoun/place/Amarillo (Texas)             Midnight Run
-properNoun/entity/Amtrack                     Midnight Run
-generic/anagram                               Sneakers
-generic/answering machine                     Sneakers
-...
-```
-
-```
-$ python -m media.tools.movies.castlist --mediapath ~/xml/m/vtmedia-schema/examples/
-Actor Name                     Movie Title                    Character Name                
-============================== ========================= ==============================
-Jane Alexander                 All The President's Men        'The Bookeeper'
-John Ashton                    Midnight Run                   Marvin Dorfler
-William Atherton               The Sugarland Express          Clovis
-Richard Attenborough           The Great Escape               Squadron Leader Roger Bartlett 'The Big X'
-Dan Aykroyd                    Sneakers                       Darryl 'Mother' Roscow
-Martin Balsam                  All The President's Men        Howard Simons
-Zöe Bell                       Death Proof                    Zöe Bell
-Steve Bisley                   Mad Max                        Jim Goose
-Kyle Bornheimer                Onward                         Wilden Lightfoot
-Matthew Broderick              Wargames                       David
-Charles Bronson                The Great Escape               Flight Lieutenant Danny Welinski 'Tunnel King'
-Jake Busey                     Road House 2: Last Call        'Wild' Bill
-Michael Chiklis                Parker                         Melander
-James Coburn                   The Great Escape               Flying Officer Sedgwick 'The Manufacturer'
-Dabney Coleman                 Wargames                       McKittrick
-Barry Corbin                   Wargames                       General Beringer
-Peter Coyote                   Enron: The Smartest Guys In The Room Narrator
-Rosario Dawson                 Death Proof                    Abernathy
-                               Unstoppable                    Connie
-Robert De Niro                 Killing Season                 Benjamin Ford
-                               Midnight Run                   Jack Walsh
-...
-```
-
-```
-$ python -m media.tools.movies.genrebreakdown
-...
-                                                        <<< Primary Genres >>>
-
-Primary Genre   Count Perc   Ratio                                              Sample Title
----------------  ----- ------ -------------------------------------------------- ---------------------------------------------
-Action               8  34.8% -----------------                                  48 Hrs.
-Adventure            3  13.0% ------                                             The Great Escape
-Documentary          1   4.3% --                                                 Enron: The Smartest Guys In The Room
-Drama                2   8.7% ----                                               All The President's Men
-Horror               1   4.3% --                                                 Death Proof
-Mystery              1   4.3% --                                                 Red Lights
-Sci-Fi               3  13.0% ------                                             Contact
-Thriller             4  17.4% --------                                           3 Days Of The Condor
----------------  ----- ------ -------------------------------------------------- ---------------------------------------------
-Total movie count 23
-
-                                                       <<< Secondary Genres >>>
-
-Primary Genre: Action  (8 / 23)
-
-Secondary Genre Count Perc   Ratio                                              Sample Title
---------------- ----- ------ -------------------------------------------------- ---------------------------------------------
-Comedy              3  33.3% ----------------                                   48 Hrs.
-Crime               2  22.2% -----------                                        Road House 2: Last Call
-Drama               1  11.1% -----                                              Killing Season
-Sci-Fi              1  11.1% -----                                              Mad Max
-Thriller            2  22.2% -----------                                        Unstoppable
---------------- ----- ------ -------------------------------------------------- ---------------------------------------------
-...
-```
-
-```
-$ python -m media.tools.movies.timebuckets --buckets 5
-Random Title                                       From     To       Count Perc   Ratio
--------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
-Mad Max                                             1:26:01  1:43:28    10  43.5% ---------------------
-Death Proof                                         1:43:28  2:00:55     8  34.8% -----------------
-All The President's Men                             2:00:55  2:18:22     3  13.0% ------
-Contact                                             2:18:22  2:35:49     1   4.3% --
-The Great Escape                                    2:35:49  2:53:16     1   4.3% --
--------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
-         Movie count : 23
-Average film runtime : 1:51:49
- Median film runtime : 1:49:59  (The Sugarland Express)
-     Interval Length : 0:17:27
-        Bucket Count : 5
-```
-
-The easiest way to test is to download a copy of the vtmedia-schema repo and use the examples there.
-
-## Python Shell Interface (Beta)
-
-Pulling data using the Python Shell.
-
-```
-$ python
-Python 3.9.7 (default, Sep  3 2021, 12:15:38) 
-[GCC 10.2.0] on sunos5
-Type "help", "copyright", "credits" or "license" for more information.
->>> import media.fileops.loader
->>> import media.fileops.repo
->>> r=media.fileops.repo.Repo('/home/user/xml/vtmedia-schema/examples/movies')
->>> r.scan()
->>> loader = media.fileops.loader.Loader()
->>> dev_list = loader.load_media(r)
->>> print(dev_list[0].contents[0].title)
-Killing Season
->>> print(dev_list[0].contents[1].title)
-Red Lights
->>> print(dev_list[1].contents[0].title)
-All The President's Men
->>> print(dev_list[2].contents[0].title)
-Unstoppable
->>> print(dev_list[3].contents[0].title)
-Road House 2: Last Call
->>> print(dev_list[4].contents[0].title)
-The Last Starfighter
->>> 
-```
-
-## Code Cleanliness
-
-All code is checked with pycodestyle and pylint before committed.
-
-```
-cd medialibrary/src
-pycodestyle media
-pylint media
-```
-
-## Unit Tests
-
-Unit tests can be run as follows:
-```
-cd medialibrary
-PYTHONPATH=src/ python -m unittest
-```
-
-### Code Cleanliness (Unit Tests)
-```
-cd medialibrary
-pycodestyle test
-PYTHONPATH=src/ pylint test
-```
+Neither of the repositories are required for operation of this module, but they provide a
+good source of sample data.
 
 ## Building
 
@@ -252,12 +22,42 @@ cd medialibrary
 python -m build 
 ```
 
-Command will generate a dist/ directory with a .tar.gz file and a .whl file.
+The build will generate a dist/ directory with a .tar.gz file and a .whl file, suitable
+for installing.
 
 ## Installing
 
-Assuming a normal Python 3 environment:
+Installaiton of the module wheel file.
 
 ```
 python -m pip install --user medialibrary-0.1-py3-none-any.whl
+```
+
+
+## Unit Tests
+
+Unit tests can be run as follows:
+```
+cd medialibrary
+PYTHONPATH=src/ python -m unittest
+```
+
+
+## Code Cleanliness
+
+### Source Module
+
+All code is checked with pycodestyle and pylint before committed.
+
+```
+cd medialibrary/src
+pycodestyle media
+pylint media
+```
+
+### Unit Tests
+```
+cd medialibrary
+pycodestyle test
+PYTHONPATH=src/ pylint test
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ media.tools.movies.namelist
 media.tools.movies.keywordlist
 media.tools.movies.castlist
 media.tools.movies.genrebreakdown
+media.tools.movies.debuglist
 ```
 
 To run these tools use.
@@ -28,6 +29,7 @@ $ python -m media.tools.movies.namelist
 $ python -m media.tools.movies.keywordlist
 $ python -m media.tools.movies.castlist
 $ python -m media.tools.movies.genrebreakdown
+$ python -m media.tools.movies.debuglist
 ```
 
 ```
@@ -195,6 +197,16 @@ Road House 2: Last Call
 >>> print(dev_list[4].contents[0].title)
 The Last Starfighter
 >>> 
+```
+
+## Code Cleanliness
+
+All code is checked with pycodestyle and pylint before committed.
+
+```
+cd medialibrary src
+pycodestyle media
+pylint media
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
 # Media Library Reader
 
-The `medialibrary` module is a Python module for reading XML files containing entertainment media
-data adhering to the vtmedia schema.
+The `medialibrary` module is a Python module for reading files containing entertainment media
+data adhering to the vtmedia schema; which is an XML schema that records details on movies
+and other works of art.
+
+```
+$ python -m media.tools.movies.list --sort runtime --random 5 --stats --mediapath ~/xml/movies
+Title                                              Year Runtime  Genre                                             
+================================================== ==== ======== ==================================================
+Total Excess: How Carolco Changed Hollywood        2020  0:59:00 [NONFICTION] Documentary "Hollywood Tell-All"     
+The Big Easy                                       1986  1:40:29 [FICTION] Drama/Comedy/Crime "Murder Investigation"
+Klute                                              1971  1:54:10 [FICTION] Mystery/Thriller "Witness Protection"   
+Air Force One                                      1997  2:04:36 [FICTION] Action/Thriller "President Plane Thriller"
+The Hot Spot                                       1990  2:10:21 [FICTION] Drama/Thriller/Romance "Con Artist Scheming"
+================================================== ==== ======== ==================================================
+  Movie count :   545
+  Sample size :     5  ( 0.92%)
+```
+
+The following repositories contain the XMLSchema definition and a sample dataset for testing the
+code.
 
 
 | Repository | Purpose |
@@ -10,54 +28,18 @@ data adhering to the vtmedia schema.
 | [mediadata](https://github.com/cjcodeproj/mediadata) | A large dataset of sample media/movie data |
 
 
-Neither of the repositories are required for operation of this module, but they provide a
-good source of sample data.
-
-## Building
-
-Assuming a normal Python 3 environment with setuptools and build modules installed:
-
-```
-cd medialibrary
-python -m build 
-```
-
-The build will generate a dist/ directory with a .tar.gz file and a .whl file, suitable
-for installing.
+Neither of these are required for module operation, but they both contain sample data and documentation on
+how to build your own files.
 
 ## Installing
 
 Installaiton of the module wheel file.
 
 ```
-python -m pip install --user medialibrary-0.1-py3-none-any.whl
+$ python -m pip install --user medialibrary-0.1-py3-none-any.whl
 ```
 
 
-## Unit Tests
+## Building
 
-Unit tests can be run as follows:
-```
-cd medialibrary
-PYTHONPATH=src/ python -m unittest
-```
-
-
-## Code Cleanliness
-
-### Source Module
-
-All code is checked with pycodestyle and pylint before committed.
-
-```
-cd medialibrary/src
-pycodestyle media
-pylint media
-```
-
-### Unit Tests
-```
-cd medialibrary
-pycodestyle test
-PYTHONPATH=src/ pylint test
-```
+See the BUILDING.md file in the source code distribution.

--- a/README.md
+++ b/README.md
@@ -204,9 +204,24 @@ The Last Starfighter
 All code is checked with pycodestyle and pylint before committed.
 
 ```
-cd medialibrary src
+cd medialibrary/src
 pycodestyle media
 pylint media
+```
+
+## Unit Tests
+
+Unit tests can be run as follows:
+```
+cd medialibrary
+PYTHONPATH=src/ python -m unittest
+```
+
+### Code Cleanliness (Unit Tests)
+```
+cd medialibrary
+pycodestyle test
+PYTHONPATH=src/ pylint test
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ media.tools.movies.show
 media.tools.movies.namelist
 media.tools.movies.keywordlist
 media.tools.movies.castlist
+media.tools.movies.genrebreakdown
 ```
 
 To run these tools use.
@@ -25,7 +26,8 @@ $ python -m media.tools.movies.list
 $ python -m media.tools.movies.show
 $ python -m media.tools.movies.namelist
 $ python -m media.tools.movies.keywordlist
-# python -m media.tools.movies.castlist
+$ python -m media.tools.movies.castlist
+$ python -m media.tools.movies.genrebreakdown
 ```
 
 ```
@@ -127,6 +129,39 @@ Rosario Dawson                 Death Proof                    Abernathy
                                Unstoppable                    Connie
 Robert De Niro                 Killing Season                 Benjamin Ford
                                Midnight Run                   Jack Walsh
+...
+```
+
+```
+$ python -m media.tools.movies.genrebreakdown
+...
+                                                        <<< Primary Genres >>>
+
+Primary Genre   Count Perc   Ratio                                              Sample Title
+---------------  ----- ------ -------------------------------------------------- ---------------------------------------------
+Action               8  34.8% -----------------                                  48 Hrs.
+Adventure            3  13.0% ------                                             The Great Escape
+Documentary          1   4.3% --                                                 Enron: The Smartest Guys In The Room
+Drama                2   8.7% ----                                               All The President's Men
+Horror               1   4.3% --                                                 Death Proof
+Mystery              1   4.3% --                                                 Red Lights
+Sci-Fi               3  13.0% ------                                             Contact
+Thriller             4  17.4% --------                                           3 Days Of The Condor
+---------------  ----- ------ -------------------------------------------------- ---------------------------------------------
+Total movie count 23
+
+                                                       <<< Secondary Genres >>>
+
+Primary Genre: Action  (8 / 23)
+
+Secondary Genre Count Perc   Ratio                                              Sample Title
+--------------- ----- ------ -------------------------------------------------- ---------------------------------------------
+Comedy              3  33.3% ----------------                                   48 Hrs.
+Crime               2  22.2% -----------                                        Road House 2: Last Call
+Drama               1  11.1% -----                                              Killing Season
+Sci-Fi              1  11.1% -----                                              Mad Max
+Thriller            2  22.2% -----------                                        Unstoppable
+--------------- ----- ------ -------------------------------------------------- ---------------------------------------------
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DVDs, and their contents.
 
 ## Executables/Demos
 
-Thre are five demonstration proof of concept executables in the library.
+Thre are eight demonstration proof of concept executables in the library.
 
 ```
 media.tools.movies.list
@@ -16,6 +16,7 @@ media.tools.movies.namelist
 media.tools.movies.keywordlist
 media.tools.movies.castlist
 media.tools.movies.genrebreakdown
+media.tools.movies.timebuckets
 media.tools.movies.debuglist
 ```
 
@@ -29,6 +30,7 @@ $ python -m media.tools.movies.namelist
 $ python -m media.tools.movies.keywordlist
 $ python -m media.tools.movies.castlist
 $ python -m media.tools.movies.genrebreakdown
+$ python -m media.tools.movies.timebuckets
 $ python -m media.tools.movies.debuglist
 ```
 
@@ -165,6 +167,23 @@ Sci-Fi              1  11.1% -----                                              
 Thriller            2  22.2% -----------                                        Unstoppable
 --------------- ----- ------ -------------------------------------------------- ---------------------------------------------
 ...
+```
+
+```
+$ python -m media.tools.movies.timebuckets --buckets 5
+Random Title                                       From     To       Count Perc   Ratio
+-------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
+Mad Max                                             1:26:01  1:43:28    10  43.5% ---------------------
+Death Proof                                         1:43:28  2:00:55     8  34.8% -----------------
+All The President's Men                             2:00:55  2:18:22     3  13.0% ------
+Contact                                             2:18:22  2:35:49     1   4.3% --
+The Great Escape                                    2:35:49  2:53:16     1   4.3% --
+-------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
+         Movie count : 23
+Average film runtime : 1:51:49
+ Median film runtime : 1:49:59  (The Sugarland Express)
+     Interval Length : 0:17:27
+        Bucket Count : 5
 ```
 
 The easiest way to test is to download a copy of the vtmedia-schema repo and use the examples there.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,399 @@
+# Command Line Tools
+
+
+The medialibrary module includes the following proof of concept tools which can 
+be called directly from the command line.
+
+
+```
+media.tools.media.list
+media.tools.media.show
+media.tools.movies.list
+media.tools.movies.show
+media.tools.movies.namelist
+media.tools.movies.keywordlist
+media.tools.movies.castlist
+media.tools.movies.genrebreakdown
+media.tools.movies.timebuckets
+media.tools.movies.debuglist
+media.tools.movies.validate
+```
+
+Every program will scan a directory full of XML files containing media and movie
+data.  Every identified file matching the correct naming convention will 
+be read, and turned into a Python object structure.
+
+## Invocation
+
+Any of the above tools can be run with the following invocation.
+
+```
+$ export MEDIAPATH=(path_to_xml_directory_structure)
+$ python -m media.tools.media.list
+```
+
+or 
+
+```
+$ python -m media.tools.media.list --mediapath (path_to_xml_directory_structure)
+```
+
+Every tool uses Python argparse for argument parsing, and provides a help option.
+
+
+## Media Tools
+
+```
+media.tools.media.list
+media.tools.media.show
+```
+
+The media tools report on data related to physical media.
+
+### Media List
+
+```
+python -m media.tools.media.list [--random (int)] [--mediapath (path)]
+```
+
+Provides a list of physical media.
+
+```
+$ python -m media.tools.media.list --random 5
+Title                                         Media Type Copies Date               
+--------------------------------------------- ---------- ------ -------------------
+3 Days Of The Condor                          Blu-Ray         1 2010-01-01 -> P3Y
+Contact                                       Blu-Ray         1 2020-01-01 -> P1Y
+Enron: The Smartest Guys In The Room          Blu-Ray         1 2021-01-11
+Road House 2: Last Call                       DVD             1 
+Unstoppable                                   Blu-Ray         2 2020-01-01
+```
+
+### Media Show
+
+```
+python -m media.tools.media.show [--random (int)] [--mediapath (path)]
+```
+
+Provides detailed descriptions of physical media.
+
+```
+$ python -m media.tools.media.show
+48 Hrs.                                                       Blu-Ray
+=====================================================================
+Library > Instances
+
+  ID Label Acquisition                    Date               
+  -------- ------------------------------ -------------------
+  UNDEF    Purchase 0.99                  2010-01-01 -> P2Y  
+
+Product Id > Codes
+
+   Barcode: 883929301737 (upc)
+
+Product Specs > Inventory
+
+  Case > Blu-Ray
+  
+Contents > Movies
+
+  Title                                    Year Genre               
+  ---------------------------------------- ---- --------------------
+  48 Hrs.                                  1982 Action/Comedy       
+
+```
+
+## Movie Tools
+
+```
+media.tools.movies.list
+media.tools.movies.show
+media.tools.movies.namelist
+media.tools.movies.keywordlist
+media.tools.movies.castlist
+media.tools.movies.genrebreakdown
+media.tools.movies.timebuckets
+media.tools.movies.debuglist
+media.tools.movies.validate
+```
+
+### Movie List
+
+```
+python -m media.tools.movies.list [--random (int)] [--mediapath (path)] [--sort (runtime|length)]
+```
+
+Provide a list of movies found in the repository.
+
+```
+$ python -m media.tools.movies.list
+Title                                              Year Genre                                             
+================================================== ==== ==================================================
+2010                                               1984 [FICTION] Sci-Fi "Space Exploration Adventure"    
+All The President's Men                            1976 [FICTION] Drama/Mystery "Newspaper Mystery"       
+Contact                                            1997 [FICTION] Sci-Fi/Drama "Alien Contact"            
+Death Proof                                        2017 [FICTION] Horror/Thriller "Car Action"            
+...
+```
+
+### Movie Show
+
+```
+python -m media.tools.movies.show [--random (int)] [--mediapath (path)] [--sort (runtime|length)]
+```
+
+Provides detailed descriptions of movies.
+
+```
+$ python -m media.tools.movies.show
+...
+All The President's Men                                               (1976)
+============================================================================
+[FICTION] Drama/Mystery "Newspaper Mystery"
+(based on a true story, based on a book)
+
+Director: Alan Pakula
+Cinemaphotographer: Gordon Willis
+Cast: Dustin Hoffman, Robert Redford, Jack Warden, Martin Balsam, Hal
+      Holbrook, Jason Robards, Jane Alexander
+
+Plot
+Two news reporters investigate the Watergate burglary and discover a
+conspiracy leading all the way to the President Of The United States.
+
+Keywords:
+ Charles Colson, CIA, Clark McGregor, Department Of Justice, Donald
+ Segretti, FBI, Hugh Sloan, investigative journalism, journalism, Ken
+ Clawson, Library Of Congress, Mark Felt, newspaper, parking garage, Richard
+ Nixon, Richard Nixon, scandal, taxi cabs, The Washington Post, Watergate
+ Conspiracy, Watergate Hotel, White House
+
+...
+```
+
+### Movie Namelist
+
+```
+python -m media.tools.movies.namelist [--random (int)] [--mediapath (path)]
+```
+
+Lists all crew and cast names associated with the movies.
+
+```
+python -m media.tools.movies.namelist
+Family Name          Given Name      Job Role             Title
+==================== =============== ==================== =========================
+Abroms               Edward          Editor               The Sugarland Express
+Alberti              Maryse          Cinemaphotographer   Enron: The Smartest Guys In The Room
+Albertson            Sean            Editor               Killing Season
+Alden Robinson       Phil            Director             Sneakers
+Alden Robinson       Phil            Writer               Sneakers
+Alexander            Jane            Cast                 All The President's Men
+Apple                Cathering       Editor               Onward
+Ashton               John            Cast                 Midnight Run
+...
+```
+
+### Movie Keywords
+
+```
+python -m media.tools.movies.keywords [--random (int)] [--mediapath (path)]
+```
+
+List all keywords found in movies.
+
+```
+$ python -m media.tools.movies.keywordlist
+Keyword                                       Title
+============================================= =========================
+properNoun/place/7-Eleven                     Wargames
+generic/accountant                            Midnight Run
+generic/affair                                Blood Simple
+generic/air duct                              The Great Escape
+properNoun/entity/Air Force                   Wargames
+generic/alcohol                               Death Proof
+generic/alien contact                         Contact
+generic/alien invasion                        The Last Starfighter
+generic/aliens                                The Last Starfighter
+properNoun/thing/Allure                       Death Proof
+properNoun/place/Amarillo (Texas)             Midnight Run
+properNoun/entity/Amtrack                     Midnight Run
+generic/anagram                               Sneakers
+generic/answering machine                     Sneakers
+...
+```
+
+### Movie Casts
+
+```
+python -m media.tools.movies.castlist [--random (int)] [--mediapath (path)]
+```
+
+List all actors found in movies.
+
+```
+$ python -m media.tools.movies.castlist --mediapath ~/xml/m/vtmedia-schema/examples/
+Actor Name                     Movie Title                    Character Name                
+============================== ========================= ==============================
+Jane Alexander                 All The President's Men        'The Bookeeper'
+John Ashton                    Midnight Run                   Marvin Dorfler
+William Atherton               The Sugarland Express          Clovis
+Richard Attenborough           The Great Escape               Squadron Leader Roger Bartlett 'The Big X'
+Dan Aykroyd                    Sneakers                       Darryl 'Mother' Roscow
+Martin Balsam                  All The President's Men        Howard Simons
+Zöe Bell                       Death Proof                    Zöe Bell
+Steve Bisley                   Mad Max                        Jim Goose
+Kyle Bornheimer                Onward                         Wilden Lightfoot
+Matthew Broderick              Wargames                       David
+Charles Bronson                The Great Escape               Flight Lieutenant Danny Welinski 'Tunnel King'
+Jake Busey                     Road House 2: Last Call        'Wild' Bill
+Michael Chiklis                Parker                         Melander
+James Coburn                   The Great Escape               Flying Officer Sedgwick 'The Manufacturer'
+Dabney Coleman                 Wargames                       McKittrick
+Barry Corbin                   Wargames                       General Beringer
+Peter Coyote                   Enron: The Smartest Guys In The Room Narrator
+Rosario Dawson                 Death Proof                    Abernathy
+                               Unstoppable                    Connie
+Robert De Niro                 Killing Season                 Benjamin Ford
+                               Midnight Run                   Jack Walsh
+...
+```
+
+### Movie Genres
+
+```
+python -m media.tools.movies.genrebreakdown [--mediapath (path)]
+```
+
+Provides a breakdown of every movie based their primary and secondary genres.
+
+```
+$ python -m media.tools.movies.genrebreakdown
+...
+                                                        <<< Primary Genres >>>
+
+Primary Genre   Count Perc   Ratio                                              Sample Title
+---------------  ----- ------ -------------------------------------------------- ---------------------------------------------
+Action               8  34.8% -----------------                                  48 Hrs.
+Adventure            3  13.0% ------                                             The Great Escape
+Documentary          1   4.3% --                                                 Enron: The Smartest Guys In The Room
+Drama                2   8.7% ----                                               All The President's Men
+Horror               1   4.3% --                                                 Death Proof
+Mystery              1   4.3% --                                                 Red Lights
+Sci-Fi               3  13.0% ------                                             Contact
+Thriller             4  17.4% --------                                           3 Days Of The Condor
+---------------  ----- ------ -------------------------------------------------- ---------------------------------------------
+Total movie count 23
+
+                                                       <<< Secondary Genres >>>
+
+Primary Genre: Action  (8 / 23)
+
+Secondary Genre Count Perc   Ratio                                              Sample Title
+--------------- ----- ------ -------------------------------------------------- ---------------------------------------------
+Comedy              3  33.3% ----------------                                   48 Hrs.
+Crime               2  22.2% -----------                                        Road House 2: Last Call
+Drama               1  11.1% -----                                              Killing Season
+Sci-Fi              1  11.1% -----                                              Mad Max
+Thriller            2  22.2% -----------                                        Unstoppable
+--------------- ----- ------ -------------------------------------------------- ---------------------------------------------
+...
+```
+
+### Movie Runlengths
+
+```
+python -m media.tools.movies.timebuckets [--mediapath (path)]
+```
+
+Sumarize the runtime of every movie.
+
+```
+$ python -m media.tools.movies.timebuckets --buckets 5
+Random Title                                       From     To       Count Perc   Ratio
+-------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
+Mad Max                                             1:26:01  1:43:28    10  43.5% ---------------------
+Death Proof                                         1:43:28  2:00:55     8  34.8% -----------------
+All The President's Men                             2:00:55  2:18:22     3  13.0% ------
+Contact                                             2:18:22  2:35:49     1   4.3% --
+The Great Escape                                    2:35:49  2:53:16     1   4.3% --
+-------------------------------------------------- -------- -------- ----- ------ --------------------------------------------------
+         Movie count : 23
+Average film runtime : 1:51:49
+ Median film runtime : 1:49:59  (The Sugarland Express)
+     Interval Length : 0:17:27
+        Bucket Count : 5
+```
+
+### Movie Debuglist 
+
+```
+python -m media.tools.movies.debuglist [--mediapath (path)]
+```
+
+Provides output useful for debugging the creation Python movie objects.  Internal tool.  Unsupported.
+
+```
+$ python -m media.tools.movies.debuglist
+Title                               Year Sort Title                          Hash                 Object Address    
+=================================== ==== ==================== ==================
+All The President's Men             1976 all_the_presidents_men              -3106834757112910740 0xfffffc7fee37df60
+Another 48 Hrs.                     1990 another_48_hrs                       6387184263348089960 0xfffffc7fee502fe0
+Blood Simple                        1984 blood_simple                         1046538065311436375 0xfffffc7fee3e9b40
+Chaos                               2005 chaos                                4753699084516088770 0xfffffc7fee5356f0
+
+```
+
+### Movie Validate
+
+```
+python -m media.tools.movies.validate [--mediapath (path)]
+```
+
+Examines movies and identifies missing or incomplete data.  Internal tool.  Unsupported.
+
+```
+$ python -m media.tools.movies.validate
+Movie Title                                        Faults
+-------------------------------------------------- -------------------------
+Blood Simple                                       Plot has less than 20 words
+Chaos                                              Plot missing
+                                                   No copyright holder info
+Enron: The Smartest Guys In The Room               Plot has less than 20 words
+The Great Escape                                   Plot missing
+```
+
+## Python Shell Interface (Beta)
+
+Pulling data using the Python Shell.
+
+In this example, a repository object is created, which identifies every suitable XML file, and a
+loader object, which is responsible for reading every suitable file and creating Media objects.
+
+The objects are returned as an array, which can be accessed directly.
+
+```
+$ python
+Python 3.9.7 (default, Sep  3 2021, 12:15:38) 
+[GCC 10.2.0] on sunos5
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import media.fileops.loader
+>>> import media.fileops.repo
+>>> r=media.fileops.repo.Repo('/home/user/xml/vtmedia-schema/examples/movies')
+>>> r.scan()
+>>> loader = media.fileops.loader.Loader()
+>>> dev_list = loader.load_media(r)
+>>> print(dev_list[0].contents[0].title)
+Killing Season
+>>> print(dev_list[0].contents[1].title)
+Red Lights
+>>> print(dev_list[1].contents[0].title)
+All The President's Men
+>>> print(dev_list[2].contents[0].title)
+Unstoppable
+>>> print(dev_list[3].contents[0].title)
+Road House 2: Last Call
+>>> print(dev_list[4].contents[0].title)
+The Last Starfighter
+>>> 
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,4 +1,4 @@
-# Command Line Tools
+# Media Library Reader -- Command Line Tools
 
 
 The medialibrary module includes the following proof of concept tools which can 
@@ -363,7 +363,7 @@ Enron: The Smartest Guys In The Room               Plot has less than 20 words
 The Great Escape                                   Plot missing
 ```
 
-## Python Shell Interface (Beta)
+## Python Shell Interface
 
 Pulling data using the Python Shell.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "medialibrary"
-version = "0.1.3"
+version = "0.1.5"
 description = "Library for reading vtmedia XML files"
 readme = "README.md"
 requires-python = ">3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
+[project]
+name = "medialibrary"
+version = "0.1.3"
+description = "Library for reading vtmedia XML files"
+readme = "README.md"
+requires-python = ">3.8"
+license = {text = "MIT License"}
+keywords = ["xml", "movies", "dvds"]
+authors = [
+  {email = "cjcodeproj@fastmail.com", name = "Chris J"}
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Text Processing :: Markup :: XML"
+]
+
+[project.urls]
+homepage = "https://github.com/cjcodeproj/medialibrary"
+"bug tracker" = "https://github.com/cjcodeproj/medialibrary/issues"
+repository = "https://github.com/cjcodeproj/medialibrary"
+changelog = "https://github.com/cjcodeproj/medialibrary/blob/main/CHANGELOG.md"
+
+
+[tools.setuptools]
+license-files = ["LICENSE"]
+
 [build-system]
 requires = [
 	"setuptools",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[metadata]
-name = medialibrary
-version = 0.1
-author = Chris J
-author_email = cj
-description = Library for vtmedia XML files
-long_description = file: README.md
-long_description_content_type = text/markdown
-classifiers =
-  Programming Language :: Python :: 3
-  License :: OSI Approved :: MIT License
-  Operating System :: OS Independent
-
 [options]
 package_dir =
         = src

--- a/src/media/__init__.py
+++ b/src/media/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/data/__init__.py
+++ b/src/media/data/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/data/dates.py
+++ b/src/media/data/dates.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+'''
+Objects for representation of dates, either exact, or a date range.
+'''
+
+# pylint: disable=too-few-public-methods
+
+
+class AbstractDate():
+    '''
+    Abstract class which has data shared by both
+    child classes.
+    '''
+    def __init__(self):
+        self.date = None
+
+
+class ExactDate(AbstractDate):
+    '''
+    Representing an exact calendar date.
+    '''
+    def __init__(self, in_element):
+        super().__init__()
+        self.date = in_element.text
+
+    def __str__(self):
+        return f"{self.date}"
+
+
+class RangeDate(AbstractDate):
+    '''
+    Representation for a non-specific date, where both an estimated start
+    and an estimated end is known.  For example, if something was acquired
+    in 2014, the start value would be 2014-01-01, and the end value would be
+    P1Y, to allow coverage for every day in 2014.
+    '''
+    def __init__(self, in_element_1, in_element_2):
+        super().__init__()
+        self.date = in_element_1.text
+        self.end = in_element_2.text
+
+    def __str__(self):
+        return f"{self.date} -> {self.end}"

--- a/src/media/data/dates.py
+++ b/src/media/data/dates.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Objects for representation of dates, either exact, or a date range.
 '''

--- a/src/media/data/media/__init__.py
+++ b/src/media/data/media/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 First classes of all media related objects.
 

--- a/src/media/data/media/contents/__init__.py
+++ b/src/media/data/media/contents/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/data/media/contents/generic/__init__.py
+++ b/src/media/data/media/contents/generic/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/data/media/contents/generic/catalog.py
+++ b/src/media/data/media/contents/generic/catalog.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Module related to the media catalog, which should be universal
 across all media types

--- a/src/media/data/media/contents/generic/catalog.py
+++ b/src/media/data/media/contents/generic/catalog.py
@@ -14,7 +14,9 @@ from media.xml.functions import xs_bool
 class Title():
     '''Movie title object'''
     def __init__(self, in_title):
-        self.title = in_title
+        self.title = in_title.strip()
+        if len(self.title) == 0:
+            raise TitleValueException("Invalid Title")
         self.sort_title = build_sort_string(self.title)
         self.file_title = build_filename_string(self.title)
 
@@ -32,6 +34,16 @@ class Title():
 
     def __str__(self):
         return self.title
+
+
+class TitleValueException(Exception):
+    '''Exception raised when a WOA has an invalid title.'''
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message
 
 
 class Catalog():

--- a/src/media/data/media/contents/generic/catalog.py
+++ b/src/media/data/media/contents/generic/catalog.py
@@ -6,7 +6,7 @@ across all media types
 
 # pylint: disable=too-few-public-methods
 
-import string
+from media.generic.stringtools import build_filename_string, build_sort_string
 from media.xml.namespaces import Namespaces
 from media.xml.functions import xs_bool
 
@@ -15,25 +15,8 @@ class Title():
     '''Movie title object'''
     def __init__(self, in_title):
         self.title = in_title
-        self._build_file_title()
-        self._build_sort_title()
-
-    def _build_file_title(self):
-        level1 = self.title.translate(
-                self.title.maketrans("", "", string.punctuation))
-        level2 = level1.casefold()
-        self.file_title = level2.translate(
-                level2.maketrans(" \t\n\r\v", "_____"))
-
-    def _build_sort_title(self):
-        level1 = self.title.translate(
-                self.title.maketrans("", "", string.punctuation))
-        level2 = level1.casefold()
-        word_split = level2.split()
-        if word_split[0] in ['the', 'a', 'an']:
-            article = word_split.pop(0)
-            word_split.append(article)
-        self.sort_title = "_".join(word_split)
+        self.sort_title = build_sort_string(self.title)
+        self.file_title = build_filename_string(self.title)
 
     def __hash__(self):
         return hash(self.sort_title)

--- a/src/media/data/media/contents/generic/catalog.py
+++ b/src/media/data/media/contents/generic/catalog.py
@@ -35,6 +35,9 @@ class Title():
             word_split.append(article)
         self.sort_title = "_".join(word_split)
 
+    def __hash__(self):
+        return hash(self.sort_title)
+
     def __lt__(self, other):
         return self.sort_title < other.sort_title
 

--- a/src/media/data/media/contents/generic/keywords.py
+++ b/src/media/data/media/contents/generic/keywords.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Keywords module
 '''
@@ -6,7 +29,7 @@ Keywords module
 # pylint: disable=too-few-public-methods
 # pylint: disable=consider-using-dict-items
 
-from media.data.nouns import Noun, Name, Place
+from media.data.nouns import Noun, Name, Place, Art
 from media.xml.namespaces import Namespaces
 
 
@@ -64,9 +87,10 @@ class Keywords():
                 self._add_group(child)
 
     def _add_single_kw(self, child):
-        if child.text.strip() != '':
-            gen_kw = GenericKeyword(child)
-            self._add_to_pool(gen_kw)
+        if child.text:
+            if child.text.strip() != '':
+                gen_kw = GenericKeyword(child)
+                self._add_to_pool(gen_kw)
 
     def _add_proper_noun(self, child):
         prn_kw = ProperNounKeyword(child)
@@ -89,13 +113,14 @@ class Keywords():
         for child in group_element:
             tname = Namespaces.ns_strip(child.tag)
             if tname == 'generic':
-                if child.text.strip() != '':
-                    gen_kw = GenericKeyword(child)
-                    if pool:
-                        gen_kw.pool = pool
-                    if relevance:
-                        gen_kw.relevance = relevance
-                    self._add_to_pool(gen_kw)
+                if child.text:
+                    if child.text.strip() != '':
+                        gen_kw = GenericKeyword(child)
+                        if pool:
+                            gen_kw.pool = pool
+                        if relevance:
+                            gen_kw.relevance = relevance
+                        self._add_to_pool(gen_kw)
             if tname == 'properNoun':
                 prn_kw = ProperNounKeyword(child)
                 if pool:
@@ -210,6 +235,8 @@ class ProperNounKeyword(AbstractKeyword):
                 self.value = Name(child)
             elif tagname == 'place':
                 self.value = Place(child)
+            elif tagname == 'art':
+                self.value = Art(child)
 
     def detail(self):
         return self.type + '/' + self.tagtype + '/' + str(self.value)

--- a/src/media/data/media/contents/generic/keywords.py
+++ b/src/media/data/media/contents/generic/keywords.py
@@ -64,8 +64,9 @@ class Keywords():
                 self._add_group(child)
 
     def _add_single_kw(self, child):
-        gen_kw = GenericKeyword(child)
-        self._add_to_pool(gen_kw)
+        if child.text.strip() != '':
+            gen_kw = GenericKeyword(child)
+            self._add_to_pool(gen_kw)
 
     def _add_proper_noun(self, child):
         prn_kw = ProperNounKeyword(child)
@@ -88,12 +89,13 @@ class Keywords():
         for child in group_element:
             tname = Namespaces.ns_strip(child.tag)
             if tname == 'generic':
-                gen_kw = GenericKeyword(child)
-                if pool:
-                    gen_kw.pool = pool
-                if relevance:
-                    gen_kw.relevance = relevance
-                self._add_to_pool(gen_kw)
+                if child.text.strip() != '':
+                    gen_kw = GenericKeyword(child)
+                    if pool:
+                        gen_kw.pool = pool
+                    if relevance:
+                        gen_kw.relevance = relevance
+                    self._add_to_pool(gen_kw)
             if tname == 'properNoun':
                 prn_kw = ProperNounKeyword(child)
                 if pool:

--- a/src/media/data/media/contents/genericv/__init__.py
+++ b/src/media/data/media/contents/genericv/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/data/media/contents/genericv/crew.py
+++ b/src/media/data/media/contents/genericv/crew.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Classes related to crewmembers of a piece
 of visual art, like a movie or television show.

--- a/src/media/data/media/contents/genericv/story.py
+++ b/src/media/data/media/contents/genericv/story.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Object classes related to the plot of a piece of
 visual media.

--- a/src/media/data/media/contents/genericv/technical.py
+++ b/src/media/data/media/contents/genericv/technical.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+'''
+Code to handle technical aspects of a vidsual format media
+(movies, television)
+'''
+
+# pylint: disable=too-few-public-methods
+
+import re
+from datetime import timedelta
+from media.xml.namespaces import Namespaces
+
+
+class Technical():
+    '''
+    Technical element block.
+
+    Covering visual format, palette, and runtime.
+    '''
+    def __init__(self, in_element):
+        self.runtime = None
+        self.palette = None
+        if in_element is not None:
+            self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            tagname = Namespaces.ns_strip(child.tag)
+            if tagname == 'runtime':
+                self.runtime = Runtime(child)
+
+
+class Runtime():
+    '''
+    Class for handling the runtime interval of a movie or TV show.
+    '''
+    def __init__(self, in_element):
+        self.overall = None
+        if in_element is not None:
+            self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            tagname = Namespaces.ns_strip(child.tag)
+            if tagname == 'overall':
+                dur_string = child.text
+                dur_value = process_iso_duration(dur_string)
+                self.overall = dur_value
+
+
+def process_iso_duration(in_string):
+    '''
+    Process an ISO duration value
+
+    Ex: like P01H20M37S (1 hour, 20 minutes, 37 seconds)
+    '''
+    duration_regex = r"PT(?P<hours>\d{1,2}H)?(?P<minutes>\d{1,2}M)?" +\
+                     r"(?P<seconds>\d{1,2}S)?"
+    dur_match = re.match(duration_regex, in_string)
+    if dur_match is not None:
+        if dur_match.group('hours') is not None:
+            in_hours = int(dur_match.group('hours').rstrip('H'))
+        else:
+            in_hours = 0
+        if dur_match.group('minutes') is not None:
+            in_minutes = int(dur_match.group('minutes').rstrip('M'))
+        else:
+            in_minutes = 0
+        if dur_match.group('seconds') is not None:
+            in_seconds = int(dur_match.group('seconds').rstrip('S'))
+        else:
+            in_seconds = 0
+        return timedelta(hours=in_hours,
+                         minutes=in_minutes,
+                         seconds=in_seconds)
+    return None

--- a/src/media/data/media/contents/genericv/technical.py
+++ b/src/media/data/media/contents/genericv/technical.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Code to handle technical aspects of a vidsual format media
 (movies, television)

--- a/src/media/data/media/contents/movie/__init__.py
+++ b/src/media/data/media/contents/movie/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 content.movie module
 '''

--- a/src/media/data/media/contents/movie/classification.py
+++ b/src/media/data/media/contents/movie/classification.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Module for movie classification
 '''

--- a/src/media/data/media/contents/movie/internal.py
+++ b/src/media/data/media/contents/movie/internal.py
@@ -4,7 +4,9 @@
 # pylint: disable=too-few-public-methods
 
 from media.xml.namespaces import Namespaces
-from media.data.media.contents.generic.catalog import Title, Catalog
+from media.data.media.contents.generic.catalog import (
+        Title, TitleValueException, Catalog
+        )
 from media.data.media.contents.genericv.story import Story
 from media.data.media.contents.genericv.crew import Crew
 from media.data.media.contents.genericv.technical import Technical
@@ -24,7 +26,10 @@ class Movie():
     def _process(self, in_chunk):
         for child in in_chunk:
             if child.tag == Namespaces.nsf('movie') + 'title':
-                self.title = Title(child.text)
+                try:
+                    self.title = Title(child.text)
+                except TitleValueException as tve:
+                    raise MovieException(tve.message) from tve
             if child.tag == Namespaces.nsf('movie') + 'catalog':
                 self.catalog = Catalog(child)
             if child.tag == Namespaces.nsf('movie') + 'classification':
@@ -73,3 +78,13 @@ class Movie():
 
     def __eq__(self, other):
         return self.unique_key == other.unique_key
+
+
+class MovieException(Exception):
+    '''Exception raised when there is an issue with a movie.'''
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/src/media/data/media/contents/movie/internal.py
+++ b/src/media/data/media/contents/movie/internal.py
@@ -37,16 +37,30 @@ class Movie():
                 self.story = Story(child)
             if child.tag == Namespaces.nsf('movie') + 'crew':
                 self.crew = Crew(child)
-        self._build_unique_key()
+        if self.title is not None:
+            self._build_unique_key()
 
     def _build_unique_key(self):
-        if self.catalog.alt_titles.variant_sort is True:
-            self.unique_key = self.catalog.alt_titles.variant_title.sort_title
+        ukv = None
+        cpy = None
+        if self.catalog is not None:
+            if self.catalog.alt_titles is not None:
+                if self.catalog.alt_titles.variant_sort is True:
+                    self.unique_key = \
+                            self.catalog.alt_titles.variant_title.sort_title
+                else:
+                    self.unique_key = self.title.sort_title
+            if self.catalog.copyright is not None:
+                cpy = str(self.catalog.copyright.year)
+            else:
+                cpy = "0000"
+            if self.catalog.unique_index is not None:
+                ukv = str(self.catalog.unique_index.index)
+            else:
+                ukv = "1"
+            self.unique_key += "-" + cpy + "-" + ukv
         else:
-            self.unique_key = self.title.sort_title
-        self.unique_key += "-" + str(self.catalog.copyright.year)
-        if self.catalog.unique_index is not None:
-            self.unique_key += "-" + str(self.catalog.unique_index.index)
+            self.unique_key = self.title.sort_title + "-0000-1"
 
     def __hash__(self):
         return hash(self.unique_key)

--- a/src/media/data/media/contents/movie/internal.py
+++ b/src/media/data/media/contents/movie/internal.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main module file for the Movie() and Title() objects'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/contents/movie/internal.py
+++ b/src/media/data/media/contents/movie/internal.py
@@ -7,6 +7,7 @@ from media.xml.namespaces import Namespaces
 from media.data.media.contents.generic.catalog import Title, Catalog
 from media.data.media.contents.genericv.story import Story
 from media.data.media.contents.genericv.crew import Crew
+from media.data.media.contents.genericv.technical import Technical
 from media.data.media.contents.movie.classification import Classification
 
 
@@ -15,6 +16,7 @@ class Movie():
     def __init__(self, in_chunk):
         self.title = None
         self.catalog = None
+        self.technical = None
         self.crew = None
         self.unique_key = ""
         self._process(in_chunk)
@@ -27,6 +29,8 @@ class Movie():
                 self.catalog = Catalog(child)
             if child.tag == Namespaces.nsf('movie') + 'classification':
                 self.classification = Classification(child)
+            if child.tag == Namespaces.nsf('movie') + 'technical':
+                self.technical = Technical(child)
             if child.tag == Namespaces.nsf('movie') + 'story':
                 self.story = Story(child)
             if child.tag == Namespaces.nsf('movie') + 'description':

--- a/src/media/data/media/internal.py
+++ b/src/media/data/media/internal.py
@@ -3,7 +3,10 @@
 
 # pylint: disable=too-few-public-methods
 
+from media.generic.stringtools import build_sort_string
 from media.xml.namespaces import Namespaces
+import media.data.media.library
+import media.data.media.medium
 import media.data.media.contents.movie
 
 
@@ -11,7 +14,10 @@ class Media():
     '''Representation of a physical thing that holds content.'''
     def __init__(self, in_chunk):
         self.title = None
+        self.library = None
+        self.medium = None
         self.contents = []
+        self.unique_key = ""
         self._process(in_chunk)
 
     def _process(self, in_chunk):
@@ -19,8 +25,17 @@ class Media():
         for child in in_chunk:
             if child.tag == Namespaces.nsf('media') + 'title':
                 self.title = Title(child)
-            if child.tag == Namespaces.nsf('media') + 'contents':
+            elif child.tag == Namespaces.nsf('media') + 'library':
+                self.library = media.data.media.library.Library(child)
+            elif child.tag == Namespaces.nsf('media') + 'medium':
+                self.medium = media.data.media.medium.Medium(child)
+            elif child.tag == Namespaces.nsf('media') + 'contents':
                 self._load_contents(child)
+        if self.title is not None:
+            self._build_unique_key()
+
+    def _build_unique_key(self):
+        self.unique_key = self.title.sort_title
 
     def _load_contents(self, in_chunk):
         '''Build an array to hold the contents in the media'''
@@ -48,6 +63,7 @@ class Title():
                 self.title = child.text
             if child.tag == Namespaces.nsf('media') + 'edition':
                 self.edition = child.text
+        self.sort_title = build_sort_string(self.title)
 
     def __str__(self):
         '''Return the title of the media'''

--- a/src/media/data/media/internal.py
+++ b/src/media/data/media/internal.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''The main media classes'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/library/__init__.py
+++ b/src/media/data/media/library/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+'''
+First classes of all media related objects.
+
+Media represents a physical device that holds
+artistic content.
+'''
+
+from .internal import *

--- a/src/media/data/media/library/__init__.py
+++ b/src/media/data/media/library/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 First classes of all media related objects.
 

--- a/src/media/data/media/library/filing.py
+++ b/src/media/data/media/library/filing.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+'''Main module file for the Movie() and Title() objects'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+
+
+class Filing():
+    '''
+    Data identifying how all instances of this media are
+    filed.
+
+    Not done to the invividual instance level, but a more
+    generic scope, where all physical copies may be kept in
+    a curated collection.
+    '''
+    def __init__(self, in_element):
+        self.catalog = ''
+        self.collections = []
+        for child in in_element:
+            c_tag = Namespaces.ns_strip(child.tag)
+            if c_tag == 'catalog':
+                self.catalog = child.text
+            if c_tag == 'collection':
+                self.collections.append(child.text)

--- a/src/media/data/media/library/filing.py
+++ b/src/media/data/media/library/filing.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main module file for the Movie() and Title() objects'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/library/instances.py
+++ b/src/media/data/media/library/instances.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+'''Main module file for the Movie() and Title() objects'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+from media.data.dates import ExactDate, RangeDate
+
+
+class Instance():
+    '''
+    Instance tracks data on a single physical copy of
+    media.  It tracks a local filing id value, an
+    acquisition, and a value tracking the condition
+    of the instance.
+    '''
+    def __init__(self, in_element):
+        self.local_id = None
+        self.acquisition = None
+        self.condition = None
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'localId':
+                self.local_id = child.text
+            elif child.tag == Namespaces.nsf('media') + 'acquisition':
+                self.acquisition = Aquisition(child)
+            elif child.tag == Namespaces.nsf('media') + 'condition':
+                self.condition = Condition(child)
+
+
+class Aquisition():
+    '''
+    Acquisition details the process of how an instance was acquired.
+    All aquisitions have a date, and further data that is either
+    a purchase or a gift.
+    '''
+    def __init__(self, in_element):
+        self.date = None
+        self.acq = None
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'date':
+                date_element = child[0]
+                if date_element.tag == Namespaces.nsf('media') + 'exact':
+                    self.date = ExactDate(date_element)
+                elif date_element.tag == Namespaces.nsf('media') + 'from':
+                    self.date = RangeDate(date_element, child[1])
+            if child.tag == Namespaces.nsf('media') + 'purchase':
+                self.acq = Purchase(child)
+            elif child.tag == Namespaces.nsf('media') + 'gift':
+                self.acq = Gift(child)
+
+    def __str__(self):
+        return f"{self.acq!s}"
+
+
+class Gift():
+    '''
+    An instance that was acquired as a gift.
+    '''
+    def __init__(self, in_element):
+        self.g_from = ''
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'from':
+                self.g_from = child.text
+
+    def __str__(self):
+        return f"Gift (from {self.g_from})"
+
+
+class Purchase():
+    '''
+    A pysical media instance that was purchased.
+    '''
+    def __init__(self, in_element):
+        self.retailer = ''
+        self.location = ''
+        self.price = 0.0
+        self.quality = ''
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'retailer':
+                self.retailer = child.text
+            if child.tag == Namespaces.nsf('media') + 'location':
+                self.location = child.text
+            if child.tag == Namespaces.nsf('media') + 'price':
+                self.price = float(child.text)
+            if child.tag == Namespaces.nsf('media') + 'quality':
+                self.quality = Namespaces.ns_strip(child[0].tag)
+
+    def __str__(self):
+        out = 'Purchase'
+        if self.price > 0:
+            out += f" {self.price:.2f}"
+        r_string = self.retailer.strip()
+        if r_string:
+            out += f" ({r_string})"
+        return out
+
+
+class Condition():
+    '''
+    Identifies the condition of the physical media.
+    '''
+    def __init__(self, in_element):
+        self.status = ''
+        self.notes = ''
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'status':
+                self.status = Namespaces.ns_strip(child[0].tag)
+            if child.tag == Namespaces.nsf('media') + 'notes':
+                self.notes = child.text

--- a/src/media/data/media/library/instances.py
+++ b/src/media/data/media/library/instances.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main module file for the Movie() and Title() objects'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/library/internal.py
+++ b/src/media/data/media/library/internal.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main module file for the Movie() and Title() objects'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/library/internal.py
+++ b/src/media/data/media/library/internal.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+'''Main module file for the Movie() and Title() objects'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+
+from media.data.media.library.instances import Instance
+from media.data.media.library.filing import Filing
+
+
+class Library():
+    '''Library object - instance tracking and local filing info.'''
+    def __init__(self, in_element):
+        self.instances = []
+        self.filing = None
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'instances':
+                self._pull_instances(child)
+            if child.tag == Namespaces.nsf('media') + 'filing':
+                self.filing = Filing(child)
+
+    def _pull_instances(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'instance':
+                self.instances.append(Instance(child))

--- a/src/media/data/media/medium/__init__.py
+++ b/src/media/data/media/medium/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+'''
+First classes of all media related objects.
+
+Media represents a physical device that holds
+artistic content.
+'''
+
+from .internal import *

--- a/src/media/data/media/medium/__init__.py
+++ b/src/media/data/media/medium/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 First classes of all media related objects.
 

--- a/src/media/data/media/medium/internal.py
+++ b/src/media/data/media/medium/internal.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main module file for the Movie() and Title() objects'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/medium/internal.py
+++ b/src/media/data/media/medium/internal.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+'''Main module file for the Movie() and Title() objects'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+
+from media.data.media.medium.release import Release, ReleaseException
+from media.data.media.medium.productid import ProductId
+from media.data.media.medium.productspecs import ProductSpecs
+
+
+class Medium():
+    '''Medium object - the physical thing'''
+    def __init__(self, in_element):
+        self.release = None
+        self.product_id = None
+        self.physical_specs = None
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'release':
+                try:
+                    self.release = Release(child)
+                except ReleaseException as rel:
+                    raise MediumException(rel.message) from rel
+            if child.tag == Namespaces.nsf('media') + 'productId':
+                self.product_id = ProductId(child)
+            if child.tag == Namespaces.nsf('media') + 'productSpecs':
+                self.product_specs = ProductSpecs(child)
+
+
+class MediumException(Exception):
+    '''
+    Exceptions related to the medium object.
+    '''
+    def __init__(self, in_message):
+        super().__init__(in_message)
+        self.message = in_message
+
+    def __str__(self):
+        return self.message

--- a/src/media/data/media/medium/inventory.py
+++ b/src/media/data/media/medium/inventory.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+'''The medium release class'''
+
+# pylint: disable=too-few-public-methods
+# pylint: disable=consider-using-dict-items
+
+import sys
+from media.xml.namespaces import Namespaces
+
+
+class AbstractPackage():
+    '''Abstract class for packaging.'''
+    def __init__(self):
+        self.media = []
+        self.type_s = 'UNDEF'
+
+    def subcontainers_list(self):
+        '''
+        Return all containers in a
+        package.
+        '''
+        out = []
+        for m_item in self.media:
+            if issubclass(m_item.__class__, AbstractCase):
+                out.append(m_item)
+        return out
+
+    def media_string_count_hash(self):
+        '''
+        Iterates through all objects in
+        the inventory.  If the object is a media
+        type, it is placed in a hash table to
+        record the type, and build an inventory
+        count.
+        '''
+        m_table = {}
+        for m_item in self.media:
+            if issubclass(m_item.__class__, AbstractMedia):
+                media_str = str(m_item)
+                if media_str in m_table:
+                    m_table[media_str] += 1
+                else:
+                    m_table[media_str] = 1
+        return m_table
+
+    def media_string_count_list(self):
+        '''
+        Return a formatted list of strings reporitng
+        inventory breakdown.  IE, if a container has
+        two DVDs and a blu-ray, it returns two strings,
+        one for each item type, with a count integer
+        if the count is greater than 1.
+        '''
+        m_list = []
+        m_table = self.media_string_count_hash()
+        for m_item in m_table:
+            if m_table[m_item] > 1:
+                m_list.append(f"{m_item} ({m_table[m_item]})")
+            else:
+                m_list.append(f"{m_item}")
+        return m_list
+
+    def __str__(self):
+        return self.type_s
+
+
+class AbstractCase(AbstractPackage):
+    '''Abstract 2nd level case.'''
+
+
+class Box(AbstractPackage):
+    '''Product case that can hold other cases.'''
+    def __init__(self, in_element):
+        super().__init__()
+        self.type_s = 'Box'
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        The _process method for Box is unique
+        because it's possible for a box
+        to contain other containers.
+
+        This method could conceivably be
+        moved to an abstract class if
+        there were other weird package
+        options that could contain other cases.
+        '''
+        if len(in_element) > 0:
+            for child in in_element:
+                child_tag = Namespaces.ns_strip(child.tag)
+                if child_tag in Containers:
+                    sub_c = Containers[child_tag](child)
+                    self.media.append(sub_c)
+
+
+class Case(AbstractCase):
+    '''Generic product case.'''
+    def __init__(self, in_element):
+        super().__init__()
+        self.type_s = 'Case'
+        self.slipcover = False
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        Identify all media or other pieces inside
+        the container and put them in the media
+        array.
+        '''
+        if 'slipcover' in in_element.attrib:
+            self.slipcover = True
+        if len(in_element) > 0:
+            for child in in_element:
+                child_tag = Namespaces.ns_strip(child.tag)
+                if child_tag in Media:
+                    sub_m = Media[child_tag](child)
+                    self.media.append(sub_m)
+
+
+class Snapcase(AbstractCase):
+    '''old style cardboard and plastic case'''
+    def __init__(self, in_element):
+        super().__init__()
+        self.type_s = 'Snapcase'
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        Identify all media or other pieces inside
+        the container and put them in the media
+        array.
+        '''
+        if len(in_element) > 0:
+            for child in in_element:
+                c_tag = Namespaces.ns_strip(child.tag)
+                if c_tag in Media:
+                    sub_m = Media[c_tag](child)
+                    self.media.append(sub_m)
+
+
+class DigiBook(AbstractCase):
+    '''media case that typically has 1 disc and 1 book.'''
+    def __init__(self, in_element):
+        super().__init__()
+        self.type_s = 'Digibook'
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        Identify all media or other pieces inside
+        the container and put them in the media
+        array.
+        '''
+        if len(in_element) > 0:
+            for child in in_element:
+                c_tag = Namespaces.ns_strip(child.tag)
+                if c_tag in Media:
+                    sub_m = Media[c_tag](child)
+                    self.media.append(sub_m)
+
+
+class Envelope(AbstractCase):
+    '''cardboard envelope.'''
+    def __init__(self, in_element):
+        super().__init__()
+        self.type_s = 'Envelope'
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        Identify all media or other pieces inside
+        the container and put them in the media
+        array.
+        '''
+        if len(in_element) > 0:
+            for child in in_element:
+                c_tag = Namespaces.ns_strip(child.tag)
+                if c_tag in Media:
+                    sub_m = Media[c_tag](child)
+                    self.media.append(sub_m)
+
+
+class AbstractMedia():
+    '''Abstract media object.'''
+    def __init__(self, in_element):
+        self.media_id = 0
+        self.type_s = 'UNDEF'
+        if in_element:
+            pass
+
+    def __str__(self):
+        return self.type_s
+
+
+class VideoDiscMedia(AbstractMedia):
+    '''Video disc class.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.radius = 5
+
+
+class DVD(VideoDiscMedia):
+    '''DVD class.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.type_s = 'DVD'
+
+
+class BluRay(VideoDiscMedia):
+    '''Blu-Ray disc class.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.type_s = 'Blu-Ray'
+
+
+class UltraHD(VideoDiscMedia):
+    '''UltraHD disc class.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.type_s = 'UltraHD'
+
+
+class Booklet(AbstractMedia):
+    '''Booklet  class.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.type_s = 'Booklet'
+
+
+class CodeSheet(AbstractMedia):
+    '''Code sheet for downloading media.'''
+    def __init__(self, in_element):
+        super().__init__(in_element)
+        self.type_s = 'Codesheet'
+
+
+#
+# The following dictionaries associate the element names
+# with the appropriate classes they represent.
+#
+
+
+Containers = {
+        'case': getattr(sys.modules[__name__], 'Case'),
+        'snapcase': getattr(sys.modules[__name__], 'Snapcase'),
+        'digibook': getattr(sys.modules[__name__], 'DigiBook'),
+        'envelope': getattr(sys.modules[__name__], 'Envelope'),
+        }
+
+Media = {
+        'ultrahd': getattr(sys.modules[__name__], 'UltraHD'),
+        'bluray': getattr(sys.modules[__name__], 'BluRay'),
+        'dvd': getattr(sys.modules[__name__], 'DVD'),
+        'booklet': getattr(sys.modules[__name__], 'Booklet'),
+        'codesheet': getattr(sys.modules[__name__], 'CodeSheet'),
+        }

--- a/src/media/data/media/medium/inventory.py
+++ b/src/media/data/media/medium/inventory.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''The medium release class'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/medium/productid.py
+++ b/src/media/data/media/medium/productid.py
@@ -1,5 +1,28 @@
 #!/usr/bin/env python
-'''The medium release class'''
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+'''The product identification classes'''
 
 # pylint: disable=too-few-public-methods
 

--- a/src/media/data/media/medium/productid.py
+++ b/src/media/data/media/medium/productid.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+'''The medium release class'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.functions import xs_bool
+from media.xml.namespaces import Namespaces
+
+
+class ProductId():
+    '''Structure for all elements pertaining to product identification.'''
+    def __init__(self, in_chunk):
+        self.barcodes = []
+        self.skus = []
+        self.others = []
+        self._process(in_chunk)
+
+    def _process(self, in_chunk):
+        for child in in_chunk:
+            if child.tag == Namespaces.nsf('media') + 'barcode':
+                self.barcodes.append(Barcode(child))
+            elif child.tag == Namespaces.nsf('media') + 'sku':
+                self.skus.append(SKU(child))
+            elif child.tag == Namespaces.nsf('media') + 'other':
+                self.others.append(OtherId(child))
+
+
+class Barcode():
+    '''Representation for a barcode on a piece of physical media.'''
+    def __init__(self, in_element):
+        self.value = None
+        self.type = None
+        self.scanlines = True
+        if in_element.text:
+            chunk = in_element.text.strip()
+            if chunk != '':
+                self.value = chunk
+        if 'type' in in_element.attrib:
+            self.type = in_element.attrib['type'].strip()
+        if 'scanlines' in in_element.attrib:
+            self.scanlines = xs_bool(in_element.attrib['scanlines'])
+
+    def __str__(self):
+        return f"{self.value} ({self.type})"
+
+
+class SKU():
+    '''Representation of a Retailer SKU for a physical piece of media.'''
+    def __init__(self, in_element):
+        self.value = None
+        self.retailer = ''
+        self.type = None
+        if in_element.text:
+            chunk = in_element.text.strip()
+            if chunk != '':
+                self.value = chunk
+        if 'retailer' in in_element.attrib:
+            self.retailer = in_element.attrib['retailer'].strip()
+        if 'type' in in_element.attrib:
+            self.type = in_element.attrib['type'].strip()
+
+    def __str__(self):
+        return f"{self.value} ({self.retailer})"
+
+
+class OtherId():
+    '''Other ID values, like a "Proof Of Purchase".'''
+    def __init__(self, in_element):
+        self.name = None
+        self.values = []
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'name':
+                self.name = child.text.strip()
+            if child.tag == Namespaces.nsf('media') + 'value':
+                self.values.append(child.text.strip())

--- a/src/media/data/media/medium/productspecs.py
+++ b/src/media/data/media/medium/productspecs.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+'''The medium release class'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+import media.data.media.medium.inventory as MI
+
+
+class ProductSpecs():
+    '''Structure for all elements pertaining to product identification.'''
+    def __init__(self, in_chunk):
+        self.inventory = None
+        self.dimensions = None
+        self._process(in_chunk)
+
+    def _process(self, in_chunk):
+        for child in in_chunk:
+            if child.tag == Namespaces.nsf('media') + 'inventory':
+                self.inventory = Inventory(child)
+            if child.tag == Namespaces.nsf('media') + 'dimensions':
+                self.dimensions = Dimensions(child)
+
+
+class Inventory():
+    '''
+    Inventory of all items in the package.
+    '''
+    def __init__(self, in_element):
+        self.inventory = []
+        self._process(in_element)
+
+    def _process(self, in_element):
+        if len(in_element) > 0:
+            for child in in_element:
+                new_t = Namespaces.ns_strip(child.tag)
+                if new_t == 'box':
+                    self.inventory.append(MI.Box(child))
+                if new_t in MI.Containers:
+                    sub_c = MI.Containers[new_t](child)
+                    # sub_c.__init__(child)
+                    self.inventory.append(sub_c)
+
+    def __str__(self):
+        out = ''
+        for itm in self.inventory:
+            out += f"{itm!s}"
+        return out
+
+
+class Dimensions():
+    '''
+    Overall dimensions of the physical media.
+    '''
+    def __init__(self, in_element):
+        self.length = 0.0
+        self.width = 0.0
+        self.height = 0.0
+        self.weight = 0.0
+        self._process(in_element)
+
+    def _process(self, in_element):
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'size':
+                self._process_size(child)
+            elif child.tag == Namespaces.nsf('media') + 'weight':
+                self._process_weight(child)
+
+    def _process_size(self, in_element):
+        '''
+        Explanation on legth, width, and height:
+
+        length and width represent the measurments of
+        the package if it was upright and lying flat on its back, which
+        means that height refers to the height of the spine.
+
+        In most measurements, length is used to refer to the
+        higher value of measurement between length and width.
+
+        Lying flat on its back, a typical US blu-ray case is 6.75
+        inches in length (or 6.75 inches tall), and
+        5.4 inches in width.  That leaves the final
+        dimension as height, which is usually 0.5 inches.
+
+        The dimensions only get set if both length and
+        width are positive values.  The height value
+        is an optional value because some storage
+        units, like Envelopes have a height value
+        so low, it's almost not worth recording.
+        '''
+        if 'length' in in_element.attrib:
+            length = float(in_element.attrib['length'])
+        if 'width' in in_element.attrib:
+            width = float(in_element.attrib['width'])
+        if 'height' in in_element.attrib:
+            height = float(in_element.attrib['height'])
+        if length > 0 and width > 0:
+            self.length = length
+            self.width = width
+            if height > 0:
+                self.height = height
+
+    def _process_weight(self, in_element):
+        if in_element.text:
+            weight = float(in_element.text)
+            if weight > 0:
+                self.weight = weight

--- a/src/media/data/media/medium/productspecs.py
+++ b/src/media/data/media/medium/productspecs.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''The medium release class'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/medium/release.py
+++ b/src/media/data/media/medium/release.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''The medium release class'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/data/media/medium/release.py
+++ b/src/media/data/media/medium/release.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+'''The medium release class'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+
+
+class Release():
+    '''
+    The release is the basic description of a physical release
+    of a work of art.
+
+    For a movie that could be a film canister, or a DVD.
+    For a story the release could be a book.
+    For a piece of music, that release could be an audio CD.
+
+    The release describes the type of release it is, who
+    published it, and the date it was released.
+    '''
+    def __init__(self, in_element):
+        self.type = None
+        self.publisher = None
+        self._process(in_element)
+
+    def _process(self, in_element):
+        '''
+        The publisher tag is easy to handle.
+        The type tag is tricky because it can only
+        contain a single XML element.
+        '''
+        for child in in_element:
+            if child.tag == Namespaces.nsf('media') + 'type':
+                if len(child) == 1:
+                    self.type = Namespaces.ns_strip(child[0].tag)
+            elif child.tag == Namespaces.nsf('media') + 'publisher':
+                self.publisher = child.text
+        if self.type is None:
+            raise ReleaseException('No media release type set.')
+
+
+class ReleaseException(Exception):
+    '''
+    The ReleaseException class is thrown when there is
+    incomplete data in the Release data structure.
+    '''
+    def __init__(self, in_message):
+        super().__init__(in_message)
+        self.message = in_message
+
+    def __str__(self):
+        return self.message
+
+
+class FormalType():
+    '''Static output representation on media types.'''
+    f_map = {
+            "cd": "CD",
+            "casette": "Casette",
+            "record": "Record",
+            "dvd": "DVD",
+            "bluray": "Blu-Ray",
+            "bluray3d": "Blu-Ray 3D",
+            "hddvd": "HD-DVD",
+            "ultrahd": "Ultra HD",
+            "vhs": "VHS",
+            "beta": "Betamax"
+        }
+
+    @classmethod
+    def formal_convert(cls, in_type):
+        '''
+        Return the type value in a more friendly string.
+        '''
+        if in_type in cls.f_map:
+            return FormalType.f_map[in_type]
+        return "UNKNOWN"

--- a/src/media/fileops/__init__.py
+++ b/src/media/fileops/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/fileops/filenames.py
+++ b/src/media/fileops/filenames.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Filename matching for the directory walker'''
 
 # pylint: disable=too-few-public-methods
@@ -8,6 +31,6 @@ import re
 
 class FilenameMatches():
     '''Static data on filename matches'''
-    # Movie_Media = re.compile("(dvd|bluray|ultrahd|vhs)(-[\n+])?.xml$")
-    Movie_Media = re.compile("-(dvd|bluray|ultrahd|vhs)(-[\\d+])?\\.xml$")
+    Movie_Media = re.compile("-(dvd|bluray|bluray3d|ultrahd|vhs)" +
+                             "(-[\\d+])?\\.xml$")
     All_Xml = re.compile("\\.xml$")

--- a/src/media/fileops/filenames.py
+++ b/src/media/fileops/filenames.py
@@ -9,4 +9,5 @@ import re
 class FilenameMatches():
     '''Static data on filename matches'''
     # Movie_Media = re.compile("(dvd|bluray|ultrahd|vhs)(-[\n+])?.xml$")
-    Movie_Media = re.compile("-(dvd|bluray|ultrahd|vhs)(-[\\d+])?\\.xml")
+    Movie_Media = re.compile("-(dvd|bluray|ultrahd|vhs)(-[\\d+])?\\.xml$")
+    All_Xml = re.compile("\\.xml$")

--- a/src/media/fileops/loader.py
+++ b/src/media/fileops/loader.py
@@ -1,5 +1,27 @@
 #!/usr/bin/env python
 
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Code relating to the loading of XML files'''
 
 # pylint: disable=too-few-public-methods

--- a/src/media/fileops/loader.py
+++ b/src/media/fileops/loader.py
@@ -2,26 +2,30 @@
 
 '''Code relating to the loading of XML files'''
 
+# pylint: disable=too-few-public-methods
+
 import media.xml.parser
+from media.fileops.filenames import FilenameMatches
 
 
 class Loader():
     '''Loads a predetermined list of media data files'''
-    def __init__(self, in_scanner):
-        self.medialist = []
-        self.scanner = in_scanner
+    def __init__(self):
+        self.file_count = 0
+        self.object_count = 0
         self.parser = media.xml.parser.Parser()
 
-    def load_media(self):
+    def load_media(self, repo, pattern=None):
         '''For each file, run the parser against it, and create an
            object if possible'''
-        for in_file in self.scanner.files:
-            self.medialist.extend(self.parser.load_file(in_file))
-
-    def file_count(self):
-        '''Return count on the number of files read'''
-        return len(self.scanner.files)
-
-    def object_count(self):
-        '''Return count on the number of media objects created'''
-        return len(self.medialist)
+        m_obj = []
+        files = []
+        if pattern is not None:
+            files = repo.file_match(pattern)
+        else:
+            files = repo.file_match(FilenameMatches.All_Xml)
+        for in_file in files:
+            self.file_count += 1
+            m_obj.extend(self.parser.load_file(in_file))
+        self.object_count += len(m_obj)
+        return m_obj

--- a/src/media/fileops/repo.py
+++ b/src/media/fileops/repo.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+'''
+Object representation of a medialibrary file repository.
+
+The object is a representation of all files under a directory tree.
+The first method call is always to scan() to identify all directories
+and files, which persist int he object memory.
+
+It contains an object that does the actual scanning work
+(which can be swapped out), and an object to do the loading
+and creation of the media objects.
+'''
+
+from media.fileops.scanner import Walker
+
+
+class Repo():
+    '''
+    The repository object.
+    '''
+    def __init__(self, in_path):
+        self.root_path = in_path
+        self.walker = Walker([in_path])
+        self.dirs = []
+        self.files = []
+
+    def set_walker(self, in_object):
+        '''
+        For the rare occasion when someone wants to swap out the default
+        walker object.
+        '''
+        self.walker = in_object
+
+    def scan(self):
+        '''
+        Have the walker object scan the repo path.
+        '''
+        self.walker.scan()
+        self.dirs = self.walker.dirs
+        self.files = self.walker.files
+
+    def file_match(self, in_pattern):
+        '''
+        Return all filenames matching a specific pattern.
+        '''
+        out = []
+        for fname in self.files:
+            if in_pattern.search(fname):
+                out.append(fname)
+        return out

--- a/src/media/fileops/repo.py
+++ b/src/media/fileops/repo.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Object representation of a medialibrary file repository.
 

--- a/src/media/fileops/scanner.py
+++ b/src/media/fileops/scanner.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Code to scan one or more directories for media files
 '''

--- a/src/media/fileops/scanner.py
+++ b/src/media/fileops/scanner.py
@@ -14,12 +14,9 @@ from os.path import isdir, isfile
 class Walker():
     '''Scans directory for media XML files'''
     def __init__(self, in_paths, debug=False):
-        # self.paths = in_paths
         self.dirs = []
         self.files = []
         self.skipped = []
-        # self.dir_count = 0
-        # self.match_count = 0
         self.elapsed = None
         self.match_re = None
         self.debug = debug
@@ -39,14 +36,9 @@ class Walker():
                     print(f"{s_dir!s} {s_file!s} {full_path!s}")
                 if isdir(full_path):
                     if not s_file.startswith('.'):
-                        # self.dir_count += 1
                         self.dirs.append(full_path)
                 elif isfile(full_path):
-                    if self.name_match(s_file):
-                        # self.match_count += 1
-                        self.files.append(full_path)
-                    else:
-                        self.skipped.append(full_path)
+                    self.files.append(full_path)
         tend = time.time()
         self.elapsed = tend - tstart
 

--- a/src/media/fmt/__init__.py
+++ b/src/media/fmt/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/fmt/text/__init__.py
+++ b/src/media/fmt/text/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/fmt/text/basics.py
+++ b/src/media/fmt/text/basics.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Formatting functions for basic plain text output.
 '''

--- a/src/media/fmt/text/basics.py
+++ b/src/media/fmt/text/basics.py
@@ -78,3 +78,31 @@ def hdr_text(header, text_block):
     out_ar = textwrap.wrap(text_block, width=DEF_WIDTH)
     out_string += "\n".join(out_ar)
     return out_string
+
+
+def hdr_list_oneper(header, i_list, indent=0, hformat='s'):
+    '''
+    Output a list with a header, one item per line.
+
+    header: item1
+            item2
+
+    allow for an indent option to pad all output
+    and a format specifier if multiple runs of
+    hdr_list_oneper need to be aligned at the colon.
+    '''
+    out = ""
+    if len(i_list) == 1:
+        f_header = f"{' ' * indent}{header:{hformat}}"
+        out = f"{f_header}: {i_list[0]}\n"
+    else:
+        f_header = f"{' ' * indent}{(header + 's'):{hformat}}"
+        bfr_string = " " * len(f_header)
+        i_count = 1
+        for i_name in i_list:
+            if i_count == 1:
+                out += f"{f_header}: {i_name}\n"
+            else:
+                out += f"{bfr_string}  {i_name}\n"
+            i_count += 1
+    return out

--- a/src/media/fmt/text/media.py
+++ b/src/media/fmt/text/media.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Classes and subroutines for media display.'''
 
 from media.data.media.medium.release import FormalType

--- a/src/media/fmt/text/media.py
+++ b/src/media/fmt/text/media.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+'''Classes and subroutines for media display.'''
+
+from media.data.media.medium.release import FormalType
+from media.fmt.text.basics import (hdr_list,
+                                   hdr_list_oneper)
+from media.fmt.text.movie import MiniEntry as MovieEntry
+
+
+class ListEntry():
+    '''
+    An entry for a piece of physical media.
+    '''
+    def __init__(self, in_media):
+        self.media = in_media
+        self.type = ''
+        self.date = ''
+        self.copies = 0
+        self.title_key = ''
+        self._prep_fields()
+        if self.type:
+            f_type = FormalType.formal_convert(self.type)
+        else:
+            f_type = 'UNKNOWN'
+        self.output = f"{self.media.title!s:45.45s} {f_type:10s} " + \
+                      f"{self.copies:6d} {self.date!s:s}"
+
+    def _prep_fields(self):
+        if self.media.medium.release:
+            if self.media.medium.release.type:
+                self.type = self.media.medium.release.type
+        if self.media.library:
+            if self.media.library.instances:
+                self.copies = len(self.media.library.instances)
+                if self.media.library.instances[0].acquisition:
+                    acq = self.media.library.instances[0].acquisition
+                    self.date = acq.date
+        self.title_key = self.media.title.sort_title
+
+    def __str__(self):
+        return self.output
+
+    @classmethod
+    def header(cls):
+        '''
+        Output a report header.
+        '''
+        output = f"{'Title':45s} {'Media Type':10s} {'Copies':6s} " + \
+                 f"{'Date':19s}\n" + \
+                 f"{'-' * 45} {'-' * 10} {'-' *6} {'-' * 19}"
+        return output
+
+
+class BriefEntry():
+    '''Formatting for a brief text record of a media device'''
+    def __init__(self, in_media):
+        self.media = in_media
+        self._prep_fields()
+        self._build_output()
+
+    def _prep_fields(self):
+        self.title_key = self.media.title.sort_title
+        if self.media.medium:
+            medm = self.media.medium
+            if medm.release:
+                self.f_type = FormalType.formal_convert(medm.release.type)
+            else:
+                self.f_type = 'UNKNOWN'
+
+    def _build_output(self):
+        self.output = self.entry_header()
+        self.output += self.library_instances_rep()
+        self.output += self.library_filing_rep()
+        self.output += self.prod_id_rec()
+        self.output += self.specs_inventory_rep()
+        self.output += self.contents_rep()
+        self.output += "\n\n"
+
+    def entry_header(self):
+        '''
+        Header line for the entry.
+        '''
+        out = f"{self.media.title!s:60s} {self.f_type:>8s}\n" + \
+              f"{'=' * 69}\n"
+        return out
+
+    def prod_id_rec(self):
+        '''Product identification information.'''
+        out = ''
+        if self.media.medium.product_id:
+            out += "Product Id > Codes\n\n"
+            ids = self.media.medium.product_id
+            if ids.barcodes:
+                out += hdr_list_oneper('Barcode',
+                                       ids.barcodes,
+                                       indent=2,
+                                       hformat=">8s")
+            if ids.skus:
+                out += hdr_list_oneper('SKU',
+                                       ids.skus,
+                                       indent=2,
+                                       hformat=">8")
+            out += "\n"
+        return out
+
+    def library_instances_rep(self, indent=2):
+        '''Library information regarding copies of media.'''
+        out = ''
+        if self.media.library:
+            lib = self.media.library
+            if lib.instances:
+                out += "Library > Instances\n\n"
+                out += f"{' ' * indent}{'ID Label'} {'Acquisition':30s} " + \
+                       f"{'Date':19s}\n" + \
+                       f"{' ' * indent}{'-' * 8} {'-' *30} {'-' * 19}\n"
+                for inst_i in lib.instances:
+                    if not inst_i.local_id:
+                        id_val = 'UNDEF'
+                    else:
+                        id_val = inst_i.local_id
+                    if not inst_i.acquisition:
+                        acq_d = 'UNKNOWN DATE'
+                    else:
+                        acq_d = inst_i.acquisition.date
+                    out += f"{' ' * indent}{id_val:8s} " + \
+                           f"{inst_i.acquisition!s:30s} " + \
+                           f"{acq_d!s:19s}\n"
+                out += "\n"
+        return out
+
+    def library_filing_rep(self):
+        '''Library information regarding filing.'''
+        out = ''
+        if self.media.library:
+            lib = self.media.library
+            if lib.filing:
+                out += "Library > Filing\n\n"
+                if lib.filing.catalog:
+                    fcat = lib.filing.catalog
+                    out += f"    {'Catalog'}: {fcat}\n"
+                if len(lib.filing.collections) > 0:
+                    out += hdr_list('    Collection',
+                                    lib.filing.collections)
+                out += "\n\n"
+        return out
+
+    def specs_inventory_rep(self):
+        '''Product Specs inventory report.'''
+        out = ''
+        if self.media.medium.product_specs:
+            out += "Product Specs > Inventory\n\n"
+            inv = self.media.medium.product_specs.inventory.inventory
+            out += media_container_list(inv, padding=2)
+            out += "\n"
+        return out
+
+    def contents_rep(self):
+        '''Report on the contents within the media object.'''
+        out = "Contents > Movies\n\n"
+        out += MovieEntry.header_line()
+        for con in self.media.contents:
+            entry = MovieEntry(con)
+            out += f"{entry!s}"
+        return out
+
+    def __str__(self):
+        return self.output
+
+
+def media_container_list(in_containers, padding=0):
+    '''
+    Take an array of containers, and then output the
+    objects within them.
+    '''
+    padding_s = f"{' ' * padding}"
+    out = padding_s
+    for m_item in in_containers:
+        out += media_container_object(m_item, padding=padding)
+    return out
+
+
+def media_container_object(in_container, padding=0, indent=0):
+    '''
+    Output the individual elements of a container.
+
+    If the container contains containers, recursively
+    call the function against the found container.
+    '''
+    padding_s = f"{' ' * padding}"
+    indent_s = f"{' ' * indent}"
+    label = str(in_container) + ' > '
+    out = label
+    subcontainers = in_container.subcontainers_list()
+    media_s = in_container.media_string_count_list()
+    for m_item in subcontainers:
+        out += media_container_object(m_item,
+                                      padding=padding,
+                                      indent=len(label))
+    m_count = 1
+    for m_item in media_s:
+        out += m_item + "\n"
+        if m_count < len(media_s):
+            out += f"{padding_s}{indent_s}{' ' * len(label)}"
+        else:
+            out += f"{padding_s}{indent_s}"
+        m_count += 1
+    return out

--- a/src/media/fmt/text/movie.py
+++ b/src/media/fmt/text/movie.py
@@ -47,6 +47,39 @@ class List():
         return self.output
 
 
+class MiniEntry():
+    '''Oneliner mini-format'''
+    def __init__(self, in_movie, in_indent=2):
+        self.movie = in_movie
+        self.indent = in_indent
+        self._prep_fields()
+        self.output = self._build_output()
+
+    @classmethod
+    def header_line(cls, in_indent=2):
+        '''Generate a simple header'''
+        out = f"{' ' * in_indent}{'Title':40s} {'Year':4s} {'Genre':20s}\n" + \
+              f"{' ' * in_indent}{'-' * 40} {'-' * 4} {'-' * 20}\n"
+        return out
+
+    def _prep_fields(self):
+        self.title_key = self.movie.unique_key
+        self.year = ''
+        self.genre = ''
+        if self.movie.catalog is not None:
+            if self.movie.catalog.copyright is not None:
+                self.year = self.movie.catalog.copyright.year
+        if self.movie.classification is not None:
+            self.genre = build_genre_simple(self.movie)
+
+    def _build_output(self):
+        return f"{' ' * self.indent}{self.movie.title!s:40s} " + \
+               f"{self.year:4d} {self.genre:20s}\n"
+
+    def __str__(self):
+        return self.output
+
+
 class Brief():
     '''Formatting for a brief text record'''
     def __init__(self, in_movie):
@@ -151,6 +184,19 @@ class Brief():
         return self.output
 
 
+def build_genre_simple(in_movie):
+    '''
+    Build a string for all genres.
+    '''
+    o_string = ''
+    classification = in_movie.classification
+    if classification.genres.primary:
+        o_string = f"{classification.genres.primary}"
+    if classification.genres.secondary:
+        o_string += '/' + '/'.join(classification.genres.secondary)
+    return o_string
+
+
 def build_genre_classification(in_movie):
     '''
     Build a text classification string.
@@ -159,10 +205,7 @@ def build_genre_classification(in_movie):
     classification = in_movie.classification
     if classification.category:
         o_string = "[" + str(classification.category) + "]"
-    if classification.genres.primary:
-        o_string += f" {classification.genres.primary}"
-    if classification.genres.secondary:
-        o_string += "/" + "/".join(classification.genres.secondary)
+    o_string += " " + build_genre_simple(in_movie)
     if classification.genres.specific:
         o_string += f" \"{classification.genres.specific}\""
     return o_string

--- a/src/media/fmt/text/movie.py
+++ b/src/media/fmt/text/movie.py
@@ -142,7 +142,9 @@ class Brief():
         out = ""
         if self.movie.story is not None:
             if self.movie.story.keywords:
-                out += hdr_block("Keyword", self.movie.story.keywords.all())
+                if len(self.movie.story.keywords.all()) > 0:
+                    out += hdr_block("Keyword",
+                                     self.movie.story.keywords.all())
         return out
 
     def __str__(self):

--- a/src/media/fmt/text/movie.py
+++ b/src/media/fmt/text/movie.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Standard text format reports for movies.
 '''
@@ -19,9 +42,16 @@ class List():
     @classmethod
     def list_header(cls):
         '''Generate a simple header'''
-        out = f"{'Title':50s} {'Year':4s} {'Runtime':8s} {'Genre':50s}\n"
-        out += f"{'=' * 50} {'=' * 4} {'=' * 8} {'=' * 50}"
+        out = f"{'Title':50s} {'Year':4s} {'Runtime':8s} {'Genre':50s}\n" + \
+              cls.list_header_line()
         return out
+
+    @classmethod
+    def list_header_line(cls):
+        """
+        Generate a text line to separate headers vs rows.
+        """
+        return f"{'=' * 50} {'=' * 4} {'=' * 8} {'=' * 50}"
 
     def _prep_fields(self):
         self.title_key = self.movie.unique_key
@@ -32,7 +62,7 @@ class List():
 
     def mentry(self):
         '''One line entry'''
-        y_string = ""
+        y_string = 0
         cat_string = ""
         if self.movie.catalog is not None:
             if self.movie.catalog.copyright is not None:
@@ -59,8 +89,15 @@ class MiniEntry():
     def header_line(cls, in_indent=2):
         '''Generate a simple header'''
         out = f"{' ' * in_indent}{'Title':40s} {'Year':4s} {'Genre':20s}\n" + \
-              f"{' ' * in_indent}{'-' * 40} {'-' * 4} {'-' * 20}\n"
+              cls.header_line_line()
         return out
+
+    @classmethod
+    def header_line_line(cls, in_indent=2):
+        """
+        Generate a line to separate headers vs rows.
+        """
+        return f"{' ' * in_indent}{'-' * 40} {'-' * 4} {'-' * 20}\n"
 
     def _prep_fields(self):
         self.title_key = self.movie.unique_key

--- a/src/media/generic/__init__.py
+++ b/src/media/generic/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/generic/stringtools.py
+++ b/src/media/generic/stringtools.py
@@ -8,9 +8,11 @@ import string
 
 def transform_string(in_value):
     '''Low level change to remove all punctuation from a string.'''
-    no_punctuation = in_value.translate(
-             in_value.maketrans("", "", string.punctuation))
-    return no_punctuation.casefold()
+    if (in_value is not None):
+        no_punctuation = in_value.translate(
+            in_value.maketrans("", "", string.punctuation))
+        return no_punctuation.casefold()
+    return "SHOULDNT BE HERE"
 
 
 def build_filename_string(in_value):

--- a/src/media/generic/stringtools.py
+++ b/src/media/generic/stringtools.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+'''Common code related to sorting operations.'''
+
+# pylint: disable=too-few-public-methods
+
+import string
+
+
+def transform_string(in_value):
+    '''Low level change to remove all punctuation from a string.'''
+    no_punctuation = in_value.translate(
+             in_value.maketrans("", "", string.punctuation))
+    return no_punctuation.casefold()
+
+
+def build_filename_string(in_value):
+    '''Convert all whitespace into underscores suitable for a filename'''
+    level1 = transform_string(in_value)
+    return level1.translate(level1.maketrans(" \t\n\r", "____"))
+
+
+def build_sort_string(in_value):
+    '''Build a string suitable for sorting, accounting for language rules.'''
+    level1 = transform_string(in_value)
+    word_split = level1.split()
+    if word_split[0] in LanguageHelpers.Articles_English:
+        article = word_split.pop(0)
+        word_split.append('_'+article)
+    return '_'.join(word_split)
+
+
+class LanguageHelpers():
+    '''Static data on languages.'''
+    Articles_English = ['a', 'an', 'the']

--- a/src/media/generic/stringtools.py
+++ b/src/media/generic/stringtools.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Common code related to sorting operations.'''
 
 # pylint: disable=too-few-public-methods
@@ -8,7 +31,7 @@ import string
 
 def transform_string(in_value):
     '''Low level change to remove all punctuation from a string.'''
-    if (in_value is not None):
+    if in_value is not None:
         no_punctuation = in_value.translate(
             in_value.maketrans("", "", string.punctuation))
         return no_punctuation.casefold()

--- a/src/media/tools/__init__.py
+++ b/src/media/tools/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 movies.tools module
 '''

--- a/src/media/tools/common.py
+++ b/src/media/tools/common.py
@@ -3,6 +3,7 @@
 
 import media.fileops.scanner
 import media.fileops.loader
+import media.fileops.repo
 from media.fileops.filenames import FilenameMatches
 
 # Walker module walks the filesystem
@@ -11,13 +12,11 @@ from media.fileops.filenames import FilenameMatches
 
 def load_media_dev(in_path):
     '''Identify suitable files and load them up'''
-    walker = media.fileops.scanner.Walker([in_path])
-    walker.filename_match(FilenameMatches.Movie_Media)
-    walker.scan()
-    mload = media.fileops.loader.Loader(walker)
-    mload.load_media()
-    media_devices = mload.medialist
-    return media_devices
+    repo = media.fileops.repo.Repo(in_path)
+    repo.scan()
+    loader = media.fileops.loader.Loader()
+    m_devices = loader.load_media(repo, FilenameMatches.Movie_Media)
+    return m_devices
 
 
 def compile_movies(media_devices):

--- a/src/media/tools/common.py
+++ b/src/media/tools/common.py
@@ -25,5 +25,6 @@ def compile_movies(media_devices):
     movies = []
     for m_dev in media_devices:
         for movie in m_dev.contents:
-            movies.append(movie)
+            if movie not in movies:
+                movies.append(movie)
     return movies

--- a/src/media/tools/common.py
+++ b/src/media/tools/common.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Common routines for command line tools'''
 
 import random

--- a/src/media/tools/common.py
+++ b/src/media/tools/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 '''Common routines for command line tools'''
 
+import random
 import media.fileops.scanner
 import media.fileops.loader
 import media.fileops.repo
@@ -27,3 +28,21 @@ def compile_movies(media_devices):
             if movie not in movies:
                 movies.append(movie)
     return movies
+
+
+def random_sample_list(in_list, rand_limit):
+    '''
+    Take a large list, and turn it into a random sample.
+    '''
+    total = len(in_list)-1
+    if rand_limit > len(in_list):
+        rand_limit = len(in_list)
+    slots = []
+    out = []
+    while len(slots) <= rand_limit-1:
+        r_num = random.randint(0, total)
+        if r_num not in slots:
+            slots.append(r_num)
+    for slot_i in slots:
+        out.append(in_list[slot_i])
+    return out

--- a/src/media/tools/media/__init__.py
+++ b/src/media/tools/media/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+'''
+media.tools.media module
+'''

--- a/src/media/tools/media/__init__.py
+++ b/src/media/tools/media/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 media.tools.media module
 '''

--- a/src/media/tools/media/list.py
+++ b/src/media/tools/media/list.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+'''
+List out all movies, one per line.
+'''
+
+# pylint: disable=R0801
+
+import os
+import argparse
+import media.fmt.text.media
+from media.tools.common import (
+        load_media_dev, random_sample_list
+        )
+
+
+def list_devices(in_list):
+    '''
+    Provide a summary list of all movies, sorted by title or runtime.
+    '''
+    print(media.fmt.text.media.ListEntry.header())
+    ordered_list = sorted(in_list, key=lambda x: x.title_key)
+    for movie_out in ordered_list:
+        print(movie_out)
+
+
+def prep_list(in_movies):
+    '''
+    Build the list of output entries.
+    '''
+    out_l = []
+    for media_i in in_movies:
+        out_l.append(media.fmt.text.media.ListEntry(media_i))
+    return out_l
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple media list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='print X random entries')
+    args = parser.parse_args()
+
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    devices = load_media_dev(mediapath)
+    if args.random:
+        chunks = prep_list(random_sample_list(devices, args.random))
+    else:
+        chunks = prep_list(devices)
+    list_devices(chunks)

--- a/src/media/tools/media/list.py
+++ b/src/media/tools/media/list.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-List out all movies, one per line.
+List out all physical media, one per line.
 '''
 
 # pylint: disable=R0801

--- a/src/media/tools/media/show.py
+++ b/src/media/tools/media/show.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+'''
+List out all movies, one per line.
+'''
+
+# pylint: disable=R0801
+
+import os
+import argparse
+import media.fmt.text.media
+from media.tools.common import (
+        load_media_dev, random_sample_list
+        )
+
+
+def list_devices(in_list):
+    '''
+    Provide a summary list of all movies, sorted by title or runtime.
+    '''
+    ordered_list = sorted(in_list, key=lambda x: x.title_key)
+    for movie_out in ordered_list:
+        print(movie_out)
+
+
+def prep_list(in_movies):
+    '''
+    Build the list of output entries.
+    '''
+    out_l = []
+    for media_i in in_movies:
+        out_l.append(media.fmt.text.media.BriefEntry(media_i))
+    return out_l
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple media list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='print X random entries')
+    args = parser.parse_args()
+
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    devices = load_media_dev(mediapath)
+    if args.random:
+        chunks = prep_list(random_sample_list(devices, args.random))
+    else:
+        chunks = prep_list(devices)
+    list_devices(chunks)

--- a/src/media/tools/media/show.py
+++ b/src/media/tools/media/show.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-List out all movies, one per line.
+List out all physical media in a detailed report.
 '''
 
 # pylint: disable=R0801

--- a/src/media/tools/movies/__init__.py
+++ b/src/media/tools/movies/__init__.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 media.tools.movies module
 '''

--- a/src/media/tools/movies/castlist.py
+++ b/src/media/tools/movies/castlist.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Module to report on all named within a movie
 '''
@@ -16,41 +39,60 @@ class ActorRoleMap():
     '''
     Align an actor with all of their roles
     '''
-    def __init__(self, in_role, in_title):
+    def __init__(self, in_role, in_movie):
         self.name = in_role.actor
-        self.titles = {}
-        self.titles[in_title] = in_role.portrays
+        self.movies = {}
+        self.movies[in_movie] = in_role.portrays
 
-    def add_title(self, in_role, in_title):
+    def add_movie(self, in_role, in_movie):
         '''
-        Add title and role data to the entry.
+        Add movie object and role data to the entry.
         '''
-        if in_title in self.titles:
-            self.titles[in_title].extend(in_role.portrays)
+        if in_movie in self.movies:
+            self.movies[in_movie].extend(in_role.portrays)
         else:
-            self.titles[in_title] = in_role.portrays
+            self.movies[in_movie] = in_role.portrays
+
+    def movie_count(self):
+        """
+        Return a count of movies for a given actor.
+        """
+        return len(self.movies.keys())
+
+    def get_movies(self):
+        """
+        Return all the movie objects for a given actor.
+        """
+        return self.movies.keys()
 
     @classmethod
     def header(cls):
         '''
-        Generate a report header/
+        Generate a report header
         '''
         out = f"{'Actor Name':30s} {'Title':30s} {'Portrays':30s}\n" + \
-              f"{'=' * 30} {'=' * 30} {'=' * 30}\n"
+              cls.header_line()
         return out
+
+    @classmethod
+    def header_line(cls):
+        """
+        Return a header line.
+        """
+        return f"{'=' * 30} {'=' * 30} {'=' * 30}\n"
 
     def __str__(self):
         out = ''
         name_c = 1
-        for title in sorted(self.titles):
+        for movie in sorted(self.movies):
             title_c = 1
-            for portrays in self.titles[title]:
+            for portrays in self.movies[movie]:
                 if name_c == 1:
-                    out += f"{self.name!s:30s} {title!s:30s} " + \
+                    out += f"{self.name!s:30s} {movie.title!s:30s} " + \
                            f"{portrays.formal!s:30s}\n"
                 else:
                     if title_c == 1:
-                        out += f"{' ':30s} {title!s:30s} " + \
+                        out += f"{' ':30s} {movie.title!s:30s} " + \
                                f"{portrays.formal!s:30s}\n"
                     else:
                         out += f"{' ':30s} {' ':30s} {portrays.formal!s:30s}\n"
@@ -78,10 +120,24 @@ def grab_cast_names(in_movies):
             if movie.crew.cast:
                 for role in movie.crew.cast.cast:
                     if role.actor in ca_dict:
-                        ca_dict[role.actor].add_title(role, movie.title)
+                        ca_dict[role.actor].add_movie(role, movie)
                     else:
-                        ca_dict[role.actor] = ActorRoleMap(role, movie.title)
+                        ca_dict[role.actor] = ActorRoleMap(role, movie)
     return list(ca_dict.values())
+
+
+def find_empty_movies(in_movies):
+    """
+    Identify movies that have no cast.
+    """
+    ca_list = []
+    for movie in in_movies:
+        if movie.crew:
+            if not movie.crew.cast:
+                ca_list.append(movie)
+        else:
+            ca_list.append(movie)
+    return ca_list
 
 
 def list_names(in_names):
@@ -91,12 +147,92 @@ def list_names(in_names):
     print(ActorRoleMap.header(), end='')
     for nm_i in sorted(in_names):
         print(nm_i, end='')
+    print(ActorRoleMap.header_line(), end='')
+
+
+def report_stats(in_names, in_sample):
+    """
+    Report stats on data, whether it's all actors
+    or a random sample.
+    """
+    all_n = stats_compile(in_names)
+    partial_n = None
+    if len(in_sample) < len(in_names):
+        partial_n = stats_compile(in_sample)
+    print()
+    if partial_n:
+        report_stats_sample(all_n, partial_n)
+    else:
+        report_stats_all(all_n)
+
+
+def report_stats_all(all_n):
+    """
+    Formatted output when no random sub-sample
+    of actor data was requested.
+    """
+    print(f"{' ':29s} {'Entire Set'}")
+    print(f"{' ':29s} {'-' * 10}")
+    print(f"{'Actor count:':29s} {all_n['names']:10d}")
+    print(f"{'Movie count:':29s} {all_n['movies']:10d}")
+    print(f"{'Average movies per actor:':29s} {all_n['act_mov_avg']:10.2f}")
+
+
+def report_stats_sample(all_n, partial_n):
+    """
+    Formatted output when a ransom sub-sample
+    of actor data was requested.
+    """
+    print(f"{' ':29s} {'Entire Set'} {'Sample Set'} {'Percentage'}")
+    print(f"{' ':29s} {'-' * 10} {'-' * 10} {'-' * 10}")
+    n_p = float(partial_n['names']) / all_n['names'] * 100
+    m_p = float(partial_n['movies']) / all_n['movies'] * 100
+    print(f"{'Actor count:':29s} " +
+          f"{all_n['names']:>10d} " +
+          f"{partial_n['names']:>10d} {n_p:9.2f}%")
+    print(f"{'Movie count:':29s} " +
+          f"{all_n['movies']:>10d} " +
+          f"{partial_n['movies']:>10d} {m_p:9.2f}%")
+    print(f"{'Average movies per actor:':29s} " +
+          f"{all_n['act_mov_avg']:10.2f} " +
+          f"{partial_n['act_mov_avg']:10.2f}")
+
+
+def stats_compile(in_names):
+    """
+    Basic statistics on actors and films.
+    A total count of the number of actors.
+    A total count of the number of movies with actors.
+    An average of how many acting jobs fo0r each
+    actor given the sample of movies.
+    """
+    out_d = {}
+    out_d['names'] = len(in_names)
+    movies_from_actors = {}
+    for act_i in in_names:
+        for movie_i in act_i.movies:
+            if movie_i in movies_from_actors:
+                movies_from_actors[movie_i] += 1
+            else:
+                movies_from_actors[movie_i] = 1
+    out_d['movies'] = len(movies_from_actors.keys())
+    act_mov_tot = 0
+    for act_i in in_names:
+        act_mov_tot += act_i.movie_count()
+    out_d['act_mov_avg'] = float(act_mov_tot) / out_d['names']
+    return out_d
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
     parser.add_argument('--random', type=int, help='show X names')
+    parser.add_argument('--stats', action=argparse.BooleanOptionalAction,
+                        help='Report statistics')
+    parser.add_argument('--report-empty',
+                        action=argparse.BooleanOptionalAction,
+                        dest='report_empty',
+                        help='Report movies with no cast')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
@@ -104,8 +240,16 @@ if __name__ == '__main__':
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
     names = grab_cast_names(all_movies)
+    empty = find_empty_movies(all_movies)
+    if len(empty) > 0 and args.report_empty:
+        print(f"{len(empty)} movies have no cast")
+        for mi in empty:
+            print(f"{str(mi.title)}")
     if args.random:
         rand_limit = args.random
-        list_names(random_sample_list(names, rand_limit))
+        sample_names = random_sample_list(names, rand_limit)
     else:
-        list_names(names)
+        sample_names = names
+    list_names(sample_names)
+    if args.stats:
+        report_stats(names, sample_names)

--- a/src/media/tools/movies/castlist.py
+++ b/src/media/tools/movies/castlist.py
@@ -7,77 +7,96 @@ Module to report on all named within a movie
 
 import os
 import argparse
-from media.tools.common import load_media_dev, compile_movies
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
 
 
-class RTP():
+class ActorRoleMap():
     '''
-    Simple pairing between a role object and a movie title object
+    Align an actor with all of their roles
     '''
-    def __init__(self, role, title):
-        self.role = role
-        self.title = title
+    def __init__(self, in_role, in_title):
+        self.name = in_role.actor
+        self.titles = {}
+        self.titles[in_title] = in_role.portrays
+
+    def add_title(self, in_role, in_title):
+        '''
+        Add title and role data to the entry.
+        '''
+        if in_title in self.titles:
+            self.titles[in_title].extend(in_role.portrays)
+        else:
+            self.titles[in_title] = in_role.portrays
+
+    @classmethod
+    def header(cls):
+        '''
+        Generate a report header/
+        '''
+        out = f"{'Actor Name':30s} {'Title':30s} {'Portrays':30s}\n" + \
+              f"{'=' * 30} {'=' * 30} {'=' * 30}\n"
+        return out
+
+    def __str__(self):
+        out = ''
+        name_c = 1
+        for title in sorted(self.titles):
+            title_c = 1
+            for portrays in self.titles[title]:
+                if name_c == 1:
+                    out += f"{self.name!s:30s} {title!s:30s} " + \
+                           f"{portrays.formal!s:30s}\n"
+                else:
+                    if title_c == 1:
+                        out += f"{' ':30s} {title!s:30s} " + \
+                               f"{portrays.formal!s:30s}\n"
+                    else:
+                        out += f"{' ':30s} {' ':30s} {portrays.formal!s:30s}\n"
+                name_c += 1
+                title_c += 1
+        return out
 
     def __lt__(self, other):
-        return self.title < other.title
+        return self.name < other.name
 
     def __rt__(self, other):
-        return self.title > other.title
+        return self.name > other.name
 
     def __eq__(self, other):
-        return self.title == other.title
+        return self.name == other.name
 
 
-class RoleList():
-    '''Build a structure of names and job roles'''
-    def __init__(self):
-        self.names = {}
-
-    def add(self, role, title):
-        '''Add a name, job role, and title to the list'''
-        actor = role.actor
-        if actor in self.names:
-            self.names[actor].append(RTP(role, title))
-        else:
-            self.names[actor] = [RTP(role, title)]
-
-    def output(self):
-        '''Return the names, job roles, and titles'''
-        print(f"{'Actor Name':30s} {'Movie Title':30s} " +
-              f"{'Character Name':30s}")
-        print(f"{'=' * 30} {'=' * 25} {'=' * 30}")
-        for nam in sorted(self.names.keys()):
-            n_count = 1
-            for role in sorted(self.names[nam]):
-                p_count = 1
-                for portrays in role.role.portrays:
-                    if n_count == 1:
-                        print(f"{nam!s:30s} {role.title!s:30s} " +
-                              f"{portrays.formal!s:s}")
-                    else:
-                        if p_count == 1:
-                            print(f"{' ':30s} {role.title!s:30s} " +
-                                  f"{portrays.formal!s:s}")
-                        else:
-                            print(f"{' ':30s} {' ':30s} {portrays.formal!s:s}")
-                    p_count += 1
-                    n_count += 1
-
-
-def grab_cast_names(movies):
-    '''Extract crew names from a movie'''
-    role_list = RoleList()
-    for movie in movies:
+def grab_cast_names(in_movies):
+    '''
+    Extract cast names from movies.
+    '''
+    ca_dict = {}
+    for movie in in_movies:
         if movie.crew is not None:
             if movie.crew.cast:
                 for role in movie.crew.cast.cast:
-                    role_list.add(role, movie.title)
-    return role_list
+                    if role.actor in ca_dict:
+                        ca_dict[role.actor].add_title(role, movie.title)
+                    else:
+                        ca_dict[role.actor] = ActorRoleMap(role, movie.title)
+    return list(ca_dict.values())
+
+
+def list_names(in_names):
+    '''
+    Output all of the passed names.
+    '''
+    print(ActorRoleMap.header(), end='')
+    for nm_i in sorted(in_names):
+        print(nm_i, end='')
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='show X names')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
@@ -85,4 +104,8 @@ if __name__ == '__main__':
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
     names = grab_cast_names(all_movies)
-    names.output()
+    if args.random:
+        rand_limit = args.random
+        list_names(random_sample_list(names, rand_limit))
+    else:
+        list_names(names)

--- a/src/media/tools/movies/debuglist.py
+++ b/src/media/tools/movies/debuglist.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 List out all movies, one per line.
 '''

--- a/src/media/tools/movies/debuglist.py
+++ b/src/media/tools/movies/debuglist.py
@@ -20,9 +20,9 @@ class DebugList():
     @classmethod
     def list_header(cls):
         '''Generate a simple header'''
-        out = f"{'Title':35s} {'Year':4s} "
-        out += f"{'Hash':20s} {'Object Address':18s}\n"
-        out += f"{'=' * 35} {'=' * 4} {'=' * 20} {'=' * 18}"
+        out = f"{'Title':35s} {'Year':4s} {'Sort Title':35s} " + \
+              f"{'Hash':20s} {'Object Address':18s}\n" + \
+              f"{'=' * 35} {'=' * 4} {'=' * 20} {'=' * 18}"
         return out
 
     def mentry(self):
@@ -32,8 +32,9 @@ class DebugList():
             if self.movie.catalog.copyright is not None:
                 y_string = self.movie.catalog.copyright.year
         hash_string = hash(self.movie)
-        out = f"{self.movie.title!s:35s} {y_string:4d} "
-        out += f"{hash_string:20d} {hex(id(self.movie))}"
+        out = f"{self.movie.title!s:35s} {y_string:4d} " + \
+              f"{self.movie.title.sort_title:35s} " + \
+              f"{hash_string:20d} {hex(id(self.movie))}"
         return out
 
     def __str__(self):

--- a/src/media/tools/movies/genrebreakdown.py
+++ b/src/media/tools/movies/genrebreakdown.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+'''
+List out all movies, one per line.
+'''
+
+# pylint: disable=R0801
+
+import os
+import argparse
+import random
+from media.tools.common import load_media_dev, compile_movies
+
+
+class PrimaryBucket():
+    '''
+    Bucket class system for primary genres.
+    '''
+    def __init__(self):
+        self.genres = {}
+        self.movie_count = 0
+
+    def add(self, genre, title):
+        '''
+        Add a title to a genre, regardless of whether it exists or not.
+        '''
+        if genre in self.genres:
+            self.genres[genre].append(title)
+        else:
+            self.genres[genre] = [title]
+        self.movie_count += 1
+
+    def bucket(self, genre):
+        '''
+        Return the list for a specific genre.
+        '''
+        if genre in self.genres:
+            return self.genres[genre]
+        return None
+
+    def report(self):
+        '''
+        Generate a primary genre report.
+        '''
+        out = f"{' ' * 55} {'<<< Primary Genres >>>'}\n\n"
+        out += f"{'Primary Genre':15s} {'Count':5s} {'Perc':6s} " + \
+               f"{'Ratio':50s} {'Sample Title'}\n"
+        out += f"{'-' * 15}  {'-' * 5} {'-' * 6} {'-' * 50} {'-' *45}\n"
+        for genre in sorted(self.genres):
+            pg_tally = len(self.genres[genre])
+            perc = float(pg_tally / self.movie_count * 100)
+            text_pro_bar = proportion_bar(pg_tally, self.movie_count)
+            rand_title = random_title(self.bucket(genre))
+            out += f"{genre:15s}  {pg_tally:5d} {perc:5.1f}% " + \
+                   f"{text_pro_bar:50s} {rand_title}\n"
+        out += f"{'-' * 15}  {'-' * 5} {'-' * 6} {'-' * 50} {'-' *45}\n"
+        out += f"Total movie count {self.movie_count}\n\n"
+        return out
+
+
+class SecondaryBucket():
+    '''
+    A class for a primary/secondary bucket tree.
+    '''
+    def __init__(self):
+        self.genres = {}
+        self.movie_count = 0
+
+    def add(self, in_primary, in_secondaries, title):
+        '''
+        Populate the primary/secondary buckets.
+        '''
+        if len(in_secondaries) == 0:
+            self._add_no_secondaries(in_primary, title)
+        else:
+            self._add_with_secondaries(in_primary, in_secondaries, title)
+        self.movie_count += 1
+
+    def _add_no_secondaries(self, in_primary, title):
+        '''
+        Add a movie to a special secondary bucket signifying
+        that there are no secondary genres for this movie.
+        '''
+        sec_genre = '(none)'
+        if in_primary in self.genres:
+            if sec_genre in self.genres[in_primary]:
+                self.genres[in_primary][sec_genre].append(title)
+            else:
+                self.genres[in_primary][sec_genre] = [title]
+        else:
+            self.genres[in_primary] = {sec_genre: [title]}
+
+    def _add_with_secondaries(self, in_primary, in_secondaries, title):
+        '''
+        Add a movie to every possible secondary genre bucket
+        for a given primary genre bucket.
+        '''
+        for sec_genre in in_secondaries:
+            if in_primary in self.genres:
+                if sec_genre in self.genres[in_primary]:
+                    self.genres[in_primary][sec_genre].append(title)
+                else:
+                    self.genres[in_primary][sec_genre] = [title]
+            else:
+                self.genres[in_primary] = {sec_genre: [title]}
+
+    def _count_primary_unique(self, in_primary):
+        '''
+        We need this to count movies under a primary genre
+        that may fall into multiple secondary buckets.
+        '''
+        out = []
+        for secondary_i in self.genres[in_primary]:
+            for title in self.genres[in_primary][secondary_i]:
+                if title not in out:
+                    out.append(title)
+        return len(out)
+
+    def bucket(self, in_primary, in_secondary):
+        '''
+        Quick routine to get to a specific bucket.
+        '''
+        if in_primary in self.genres:
+            if in_secondary in self.genres[in_primary]:
+                return self.genres[in_primary][in_secondary]
+        return None
+
+    def report(self):
+        '''
+        Generate a secondary genre report.
+        '''
+        out = f"{' ' * 54} {'<<< Secondary Genres >>>'}\n\n"
+        for primary_i in sorted(self.genres):
+            sec_tally = 0
+            for secondary_i in self.genres[primary_i]:
+                sec_tally += len(self.genres[primary_i][secondary_i])
+            prim_count = self._count_primary_unique(primary_i)
+            out += f"\nPrimary Genre: {primary_i}  ({prim_count} / " + \
+                   f"{self.movie_count})\n\n"
+            out += f"{'Secondary Genre':15s} {'Count':5s} {'Perc':6s} " + \
+                   f"{'Ratio':50s} {'Sample Title'}\n"
+            out += f"{'-' * 15} {'-' * 5} {'-' * 6} {'-' * 50} {'-' * 45}\n"
+            for secondary_i in sorted(self.genres[primary_i]):
+                sec_count = len(self.genres[primary_i][secondary_i])
+                perc = float(sec_count / sec_tally * 100)
+                text_pro_bar = proportion_bar(sec_count, sec_tally)
+                rand_title = random_title(self.genres[primary_i][secondary_i])
+                out += f"{secondary_i:15s} {sec_count:5d} {perc:5.1f}% " + \
+                       f"{text_pro_bar:50s} {rand_title}\n"
+            out += f"{'-' * 15} {'-' * 5} {'-' * 6} {'-' * 50} {'-' * 45}\n"
+        return out
+
+
+def report_header():
+    '''
+    Print a simplified report header.
+    '''
+    out = f"{'=' * 132}\n\n"
+    out += f" {'Movie Genre Report'}\n\n"
+    out += f"{'=' * 132}\n\n"
+    return out
+
+
+def populate_primary_buckets(movies):
+    '''Put the primary genre of every movie in a bucket.'''
+    pg_bucket = PrimaryBucket()
+    for movie in movies:
+        if movie.classification.genres:
+            prim_genre = movie.classification.genres.primary
+            pg_bucket.add(prim_genre, movie.title)
+    return pg_bucket
+
+
+def populate_secondary_buckets(movies):
+    '''Put the primary and secondary genres of every movie in a bucket.'''
+    sg_bucket = SecondaryBucket()
+    for movie in movies:
+        if movie.classification.genres:
+            prim_genre = movie.classification.genres.primary
+            sec_genre = movie.classification.genres.secondary
+            sg_bucket.add(prim_genre, sec_genre, movie.title)
+    return sg_bucket
+
+
+def proportion_bar(value, maximum, limit=50):
+    '''
+    Generate a proportional text bar based on a set of values, including
+    the desired value, the maximum possible value, and the
+    character limit on how long the bar can be.
+    '''
+    ratio = int(value / maximum * limit)
+    tics = ratio * '-'
+    return f"{tics}"
+
+
+def random_title(in_list):
+    '''
+    For a given list of movie titles, return one random
+    title from the list.
+    '''
+    total_count = len(in_list)
+    if total_count == 1:
+        random_index = 0
+    else:
+        random_index = random.randint(0, len(in_list)-1)
+    return str(in_list[random_index])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple movie list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    args = parser.parse_args()
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    devices = load_media_dev(mediapath)
+    all_movies = compile_movies(devices)
+    primary = populate_primary_buckets(all_movies)
+    secondary = populate_secondary_buckets(all_movies)
+    print(report_header())
+    print(primary.report())
+    print(secondary.report())

--- a/src/media/tools/movies/genrebreakdown.py
+++ b/src/media/tools/movies/genrebreakdown.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-List out all movies, one per line.
+List out all movie genres, grouped by primary and secondary genres.
 '''
 
 # pylint: disable=R0801
@@ -14,19 +37,22 @@ from media.tools.common import load_media_dev, compile_movies
 class PrimaryBucket():
     '''
     Bucket class system for primary genres.
+
+    Very simple dictionary where key values are the primary genre name, and
+    the value is a list containing the movie objects.
     '''
     def __init__(self):
         self.genres = {}
         self.movie_count = 0
 
-    def add(self, genre, title):
+    def add(self, genre, movie):
         '''
-        Add a title to a genre, regardless of whether it exists or not.
+        Add a movie to a genre, regardless of whether it exists or not.
         '''
         if genre in self.genres:
-            self.genres[genre].append(title)
+            self.genres[genre].append(movie)
         else:
-            self.genres[genre] = [title]
+            self.genres[genre] = [movie]
         self.movie_count += 1
 
     def bucket(self, genre):
@@ -49,9 +75,9 @@ class PrimaryBucket():
             pg_tally = len(self.genres[genre])
             perc = float(pg_tally / self.movie_count * 100)
             text_pro_bar = proportion_bar(pg_tally, self.movie_count)
-            rand_title = random_title(self.bucket(genre))
+            rand_movie = random_movie(self.bucket(genre))
             out += f"{genre:15s}  {pg_tally:5d} {perc:5.1f}% " + \
-                   f"{text_pro_bar:50s} {rand_title}\n"
+                   f"{text_pro_bar:50s} {rand_movie.title!s}\n"
         out += f"{'-' * 15}  {'-' * 5} {'-' * 6} {'-' * 50} {'-' *45}\n"
         out += f"Total movie count {self.movie_count}\n\n"
         return out
@@ -60,22 +86,27 @@ class PrimaryBucket():
 class SecondaryBucket():
     '''
     A class for a primary/secondary bucket tree.
+
+    A slightly more complex dictionary compared to PrimaryBucket.
+    Each key is still based on the value of 'primary', but the value is another
+    dictionary, with each key of the smaller dictionary being the values of
+    the 'secondary' elements, and the value being a list of movie objects.
     '''
     def __init__(self):
         self.genres = {}
         self.movie_count = 0
 
-    def add(self, in_primary, in_secondaries, title):
+    def add(self, in_primary, in_secondaries, movie):
         '''
         Populate the primary/secondary buckets.
         '''
         if len(in_secondaries) == 0:
-            self._add_no_secondaries(in_primary, title)
+            self._add_no_secondaries(in_primary, movie)
         else:
-            self._add_with_secondaries(in_primary, in_secondaries, title)
+            self._add_with_secondaries(in_primary, in_secondaries, movie)
         self.movie_count += 1
 
-    def _add_no_secondaries(self, in_primary, title):
+    def _add_no_secondaries(self, in_primary, movie):
         '''
         Add a movie to a special secondary bucket signifying
         that there are no secondary genres for this movie.
@@ -83,13 +114,13 @@ class SecondaryBucket():
         sec_genre = '(none)'
         if in_primary in self.genres:
             if sec_genre in self.genres[in_primary]:
-                self.genres[in_primary][sec_genre].append(title)
+                self.genres[in_primary][sec_genre].append(movie)
             else:
-                self.genres[in_primary][sec_genre] = [title]
+                self.genres[in_primary][sec_genre] = [movie]
         else:
-            self.genres[in_primary] = {sec_genre: [title]}
+            self.genres[in_primary] = {sec_genre: [movie]}
 
-    def _add_with_secondaries(self, in_primary, in_secondaries, title):
+    def _add_with_secondaries(self, in_primary, in_secondaries, movie):
         '''
         Add a movie to every possible secondary genre bucket
         for a given primary genre bucket.
@@ -97,23 +128,36 @@ class SecondaryBucket():
         for sec_genre in in_secondaries:
             if in_primary in self.genres:
                 if sec_genre in self.genres[in_primary]:
-                    self.genres[in_primary][sec_genre].append(title)
+                    self.genres[in_primary][sec_genre].append(movie)
                 else:
-                    self.genres[in_primary][sec_genre] = [title]
+                    self.genres[in_primary][sec_genre] = [movie]
             else:
-                self.genres[in_primary] = {sec_genre: [title]}
+                self.genres[in_primary] = {sec_genre: [movie]}
 
     def _count_primary_unique(self, in_primary):
         '''
         We need this to count movies under a primary genre
         that may fall into multiple secondary buckets.
+
+        This function creates a list and iterates through
+        all of the movies, but only adds the movie object to
+        the list if it isn't already present.
         '''
         out = []
         for secondary_i in self.genres[in_primary]:
-            for title in self.genres[in_primary][secondary_i]:
-                if title not in out:
-                    out.append(title)
+            for movie in self.genres[in_primary][secondary_i]:
+                if movie not in out:
+                    out.append(movie)
         return len(out)
+
+    def _count_secondary_occurences(self, in_primary_g):
+        sec_occur = 0
+        for prim_g in self.genres:
+            for sec_g in self.genres[prim_g]:
+                if sec_g == in_primary_g:
+                    # sec_occur += 1
+                    sec_occur += len(self.genres[prim_g][sec_g])
+        return sec_occur
 
     def bucket(self, in_primary, in_secondary):
         '''
@@ -134,18 +178,20 @@ class SecondaryBucket():
             for secondary_i in self.genres[primary_i]:
                 sec_tally += len(self.genres[primary_i][secondary_i])
             prim_count = self._count_primary_unique(primary_i)
-            out += f"\nPrimary Genre: {primary_i}  ({prim_count} / " + \
-                   f"{self.movie_count})\n\n"
-            out += f"{'Secondary Genre':15s} {'Count':5s} {'Perc':6s} " + \
+            sec_occur = self._count_secondary_occurences(primary_i)
+            out += f"\nPrimary Genre: {primary_i:12s}  ({prim_count:d} / " + \
+                   f"{self.movie_count:d}) "
+            out += f"Occurences as a secondary genre: {sec_occur}\n\n"
+            out += f"{'Secondary Genre':12s} {'Count':5s} {'Perc':6s} " + \
                    f"{'Ratio':50s} {'Sample Title'}\n"
             out += f"{'-' * 15} {'-' * 5} {'-' * 6} {'-' * 50} {'-' * 45}\n"
             for secondary_i in sorted(self.genres[primary_i]):
                 sec_count = len(self.genres[primary_i][secondary_i])
                 perc = float(sec_count / sec_tally * 100)
                 text_pro_bar = proportion_bar(sec_count, sec_tally)
-                rand_title = random_title(self.genres[primary_i][secondary_i])
+                rand_movie = random_movie(self.genres[primary_i][secondary_i])
                 out += f"{secondary_i:15s} {sec_count:5d} {perc:5.1f}% " + \
-                       f"{text_pro_bar:50s} {rand_title}\n"
+                       f"{text_pro_bar:50s} {rand_movie.title!s}\n"
             out += f"{'-' * 15} {'-' * 5} {'-' * 6} {'-' * 50} {'-' * 45}\n"
         return out
 
@@ -166,7 +212,7 @@ def populate_primary_buckets(movies):
     for movie in movies:
         if movie.classification.genres:
             prim_genre = movie.classification.genres.primary
-            pg_bucket.add(prim_genre, movie.title)
+            pg_bucket.add(prim_genre, movie)
     return pg_bucket
 
 
@@ -177,7 +223,7 @@ def populate_secondary_buckets(movies):
         if movie.classification.genres:
             prim_genre = movie.classification.genres.primary
             sec_genre = movie.classification.genres.secondary
-            sg_bucket.add(prim_genre, sec_genre, movie.title)
+            sg_bucket.add(prim_genre, sec_genre, movie)
     return sg_bucket
 
 
@@ -192,17 +238,17 @@ def proportion_bar(value, maximum, limit=50):
     return f"{tics}"
 
 
-def random_title(in_list):
+def random_movie(in_list):
     '''
-    For a given list of movie titles, return one random
-    title from the list.
+    For a given list of movies, return one random
+    movie from the list.
     '''
     total_count = len(in_list)
     if total_count == 1:
         random_index = 0
     else:
         random_index = random.randint(0, len(in_list)-1)
-    return str(in_list[random_index])
+    return in_list[random_index]
 
 
 if __name__ == '__main__':

--- a/src/media/tools/movies/keywordlist.py
+++ b/src/media/tools/movies/keywordlist.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-Module to report on all named within a movie
+Module to report on all keywords within a movie
 '''
 
 # pylint: disable=R0801

--- a/src/media/tools/movies/list.py
+++ b/src/media/tools/movies/list.py
@@ -1,7 +1,31 @@
 #!/usr/bin/env python
-'''
-List out all movies, one per line.
-'''
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""
+List out all movies (or a random sample of all movies),
+one apiece per line.
+"""
 
 # pylint: disable=R0801
 
@@ -24,6 +48,7 @@ def list_movies(in_list, sort_field=None):
     print(media.fmt.text.movie.List.list_header())
     for movie_out in order_list:
         print(movie_out)
+    print(media.fmt.text.movie.List.list_header_line())
 
 
 def prep_list(in_movies):
@@ -36,12 +61,27 @@ def prep_list(in_movies):
     return out_l
 
 
+def report_stats(in_full, in_sample):
+    """
+    Report on the data collected.
+    """
+    a_c = len(in_full)
+    s_c = len(in_sample)
+    print(f"  Movie count : {a_c:5d}")
+    if s_c < a_c:
+        c_percent = float(s_c) / a_c * 100
+        print(f"  Sample size : {s_c:5d}  ({c_percent:5.2f}%)")
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
     parser.add_argument('--random', type=int, help='print X random entries')
     parser.add_argument('--sort', choices=['title', 'runtime'],
                         help='Sort field')
+    parser.add_argument('--stats',
+                        action=argparse.BooleanOptionalAction,
+                        help='Report statistics')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
@@ -49,10 +89,12 @@ if __name__ == '__main__':
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
     if args.random:
-        chunks = prep_list(random_sample_list(all_movies, args.random))
+        sample = prep_list(random_sample_list(all_movies, args.random))
     else:
-        chunks = prep_list(all_movies)
+        sample = prep_list(all_movies)
     if args.sort:
-        list_movies(chunks, args.sort)
+        list_movies(sample, args.sort)
     else:
-        list_movies(chunks)
+        list_movies(sample)
+    if args.stats:
+        report_stats(all_movies, sample)

--- a/src/media/tools/movies/list.py
+++ b/src/media/tools/movies/list.py
@@ -13,18 +13,35 @@ from media.tools.common import (
         )
 
 
-def list_movies(movies):
-    '''Provide a summary list of all movies'''
+def list_movies(in_list, sort_field=None):
+    '''
+    Provide a summary list of all movies, sorted by title or runtime.
+    '''
+    if sort_field == 'runtime':
+        order_list = sorted(in_list, key=lambda x: x.runtime)
+    else:
+        order_list = sorted(in_list, key=lambda x: x.title_key)
     print(media.fmt.text.movie.List.list_header())
-    for movie in sorted(movies):
-        movie_list_entry = media.fmt.text.movie.List(movie)
-        print(movie_list_entry)
+    for movie_out in order_list:
+        print(movie_out)
+
+
+def prep_list(in_movies):
+    '''
+    Build the list of output entries.
+    '''
+    out_l = []
+    for movie in in_movies:
+        out_l.append(media.fmt.text.movie.List(movie))
+    return out_l
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
     parser.add_argument('--random', type=int, help='print X random entries')
+    parser.add_argument('--sort', choices=['title', 'runtime'],
+                        help='Sort field')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
@@ -32,7 +49,10 @@ if __name__ == '__main__':
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
     if args.random:
-        rand_limit = args.random
-        list_movies(random_sample_list(all_movies, rand_limit))
+        chunks = prep_list(random_sample_list(all_movies, args.random))
     else:
-        list_movies(all_movies)
+        chunks = prep_list(all_movies)
+    if args.sort:
+        list_movies(chunks, args.sort)
+    else:
+        list_movies(chunks)

--- a/src/media/tools/movies/list.py
+++ b/src/media/tools/movies/list.py
@@ -8,7 +8,9 @@ List out all movies, one per line.
 import os
 import argparse
 import media.fmt.text.movie
-from media.tools.common import load_media_dev, compile_movies
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
 
 
 def list_movies(movies):
@@ -22,10 +24,15 @@ def list_movies(movies):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='print X random entries')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
         parser.print_help()
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
-    list_movies(all_movies)
+    if args.random:
+        rand_limit = args.random
+        list_movies(random_sample_list(all_movies, rand_limit))
+    else:
+        list_movies(all_movies)

--- a/src/media/tools/movies/namelist.py
+++ b/src/media/tools/movies/namelist.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Module to report on all named within a movie
 '''

--- a/src/media/tools/movies/namelist.py
+++ b/src/media/tools/movies/namelist.py
@@ -7,73 +7,140 @@ Module to report on all named within a movie
 
 import os
 import argparse
-from media.tools.common import load_media_dev, compile_movies
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
 
 
-class NameList():
-    '''Build a structure of names and job roles'''
-    def __init__(self):
-        self.names = {}
+class NameJobTitleMap():
+    '''Crewname object that lists every job role in every title.
+    '''
+    def __init__(self, in_name, in_job, in_title):
+        self.name = in_name
+        self.jobs = {}
+        self.jobs[in_job] = [in_title]
 
-    def add(self, name, job_role, title):
-        '''Add a name, job role, and title to the list'''
-        if name in self.names:
-            if job_role in self.names[name]:
-                self.names[name][job_role].append(title)
-            else:
-                self.names[name][job_role] = [title]
+    def add_job_title(self, in_job, in_title):
+        '''
+        Add a job role and movie title to the name.
+        '''
+        if in_job in self.jobs:
+            self.jobs[in_job].append(in_title)
         else:
-            self.names[name] = {}
-            self.names[name][job_role] = [title]
+            self.jobs[in_job] = [in_title]
 
-    def output(self):
-        '''Return the names, job roles, and titles'''
-        print(f"{'Family Name':20s} {'Given Name':15s} " +
-              f"{'Job Role':20s} {'Title'}")
-        print(f"{'=' * 20} {'=' * 15} {'=' * 20} {'=' * 25}")
-        for nam in sorted(self.names.keys()):
-            for j_role in sorted(self.names[nam].keys()):
-                t_count = 1
-                for title in sorted(self.names[nam][j_role]):
-                    if t_count == 1:
-                        print(f"{nam.family:20s} {nam.given:15s} " +
-                              f"{j_role:20s} {title!s}")
+    @classmethod
+    def header(cls):
+        '''
+        Output a simple header.
+        '''
+        out = f"{'Family Name':20s} {'Given Name':15s} " + \
+              f"{'Job':20s} {'Title':25s}\n" + \
+              f"{'=' * 20} {'=' * 15} {'=' * 20} {'=' * 25}"
+        return out
+
+    def __str__(self):
+        out = ''
+        name_l = 1
+        for job_i in sorted(self.jobs):
+            job_l = 1
+            for title_i in sorted(self.jobs[job_i]):
+                if name_l == 1:
+                    out = f"{self.name.family:20s} {self.name.given:15s} " + \
+                          f"{job_i:20s} {title_i!s:25s}\n"
+                else:
+                    if job_l == 1:
+                        out += f"{' ':36s} {job_i:20s} {title_i!s:25s}\n"
                     else:
-                        print(f"{' ':20s} {' ':15s} {j_role:20s} {title!s}")
-                    t_count += 1
+                        out += f"{' ':57s} {title_i!s:25s}\n"
+                job_l += 1
+                name_l += 1
+        return out
+
+    def __lt__(self, other):
+        return self.name < other.name
+
+    def __gt__(self, other):
+        return self.name > other.name
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+
+def extract_from_list(in_dict, in_crew_job, in_job_title, in_movie_title):
+    '''
+    Extract the name of a crew member from a job array.
+    '''
+    for name_i in in_crew_job:
+        if name_i in in_dict:
+            in_dict[name_i].add_job_title(in_job_title, in_movie_title)
+        else:
+            in_dict[name_i] = NameJobTitleMap(name_i, in_job_title,
+                                              in_movie_title)
+
+
+def extract_role_from_list(in_dict, in_crew_roles,
+                           in_job_title, in_movie_title):
+    '''
+    Extract the name of the actor from a role object.
+    '''
+    for name_i in in_crew_roles:
+        if name_i.actor in in_dict:
+            in_dict[name_i.actor].add_job_title(in_job_title, in_movie_title)
+        else:
+            in_dict[name_i.actor] = NameJobTitleMap(name_i.actor,
+                                                    in_job_title,
+                                                    in_movie_title)
 
 
 def grab_crew_names(movies):
-    '''Extract crew names from a movie'''
-    name_list = NameList()
+    '''
+    Extract name objects from the arrays specific to
+    the job functions.
+    '''
+    nm_dict = {}
     for movie in movies:
         if movie.crew is not None:
             if movie.crew.directors:
-                for dir_n in movie.crew.directors:
-                    name_list.add(dir_n, "Director", movie.title)
+                extract_from_list(nm_dict, movie.crew.directors,
+                                  'Director', movie.title)
             if movie.crew.writers:
-                for writ_n in movie.crew.writers:
-                    name_list.add(writ_n, "Writer", movie.title)
+                extract_from_list(nm_dict, movie.crew.writers,
+                                  'Writer', movie.title)
             if movie.crew.cinemap:
-                for cinemap_n in movie.crew.cinemap:
-                    name_list.add(cinemap_n, "Cinemaphotographer", movie.title)
+                extract_from_list(nm_dict, movie.crew.cinemap,
+                                  'Cinemaphotographer', movie.title)
             if movie.crew.editors:
-                for editor_n in movie.crew.editors:
-                    name_list.add(editor_n, "Editor", movie.title)
+                extract_from_list(nm_dict, movie.crew.editors,
+                                  'Editor', movie.title)
             if movie.crew.cast:
-                for role in movie.crew.cast.cast:
-                    name_list.add(role.actor, "Cast", movie.title)
-    return name_list
+                extract_role_from_list(nm_dict, movie.crew.cast.cast,
+                                       'Cast', movie.title)
+    return list(nm_dict.values())
+
+
+def list_names(in_names):
+    '''
+    Generate output from the list of passed names.
+    '''
+    print(NameJobTitleMap.header())
+    for name_i in sorted(in_names):
+        print(name_i, end='')
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='show X names')
     args = parser.parse_args()
     mediapath = args.mediapath or os.environ['MEDIAPATH']
     if not mediapath:
         parser.print_help()
     devices = load_media_dev(mediapath)
     all_movies = compile_movies(devices)
-    names = grab_crew_names(all_movies)
-    names.output()
+    all_names = grab_crew_names(all_movies)
+    if args.random:
+        rand_limit = args.random
+        list_names(random_sample_list(all_names, rand_limit))
+    else:
+        list_names(all_names)

--- a/src/media/tools/movies/show.py
+++ b/src/media/tools/movies/show.py
@@ -7,7 +7,9 @@
 import os
 import argparse
 import media.fmt.text.movie
-from media.tools.common import load_media_dev, compile_movies
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
 
 
 def print_movies(movies):
@@ -20,10 +22,15 @@ def print_movies(movies):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='print X random entries')
     args = parser.parse_args()
     moviepath = args.mediapath or os.environ['MEDIAPATH']
     if not moviepath:
         parser.print_help()
     devices = load_media_dev(moviepath)
     all_movies = compile_movies(devices)
-    print_movies(all_movies)
+    if args.random:
+        rand_limit = args.random
+        print_movies(random_sample_list(all_movies, rand_limit))
+    else:
+        print_movies(all_movies)

--- a/src/media/tools/movies/show.py
+++ b/src/media/tools/movies/show.py
@@ -12,17 +12,34 @@ from media.tools.common import (
         )
 
 
-def print_movies(movies):
-    '''Do a brief report on the movies'''
-    for movie in sorted(movies):
-        movie_record = media.fmt.text.movie.Brief(movie)
-        print(movie_record)
+def show_movies(in_list, sort_field=None):
+    '''
+    Show every movie entry, ordered by either title or runtime.
+    '''
+    if sort_field == 'runtime':
+        order_list = sorted(in_list, key=lambda x: x.runtime)
+    else:
+        order_list = sorted(in_list, key=lambda x: x.title_key)
+    for movie_out in order_list:
+        print(movie_out)
+
+
+def prep_list(in_movies):
+    '''
+    Build the list of output entries.
+    '''
+    out_l = []
+    for movie in in_movies:
+        out_l.append(media.fmt.text.movie.Brief(movie))
+    return out_l
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Simple movie list.')
     parser.add_argument('--mediapath', help='path of media library')
     parser.add_argument('--random', type=int, help='print X random entries')
+    parser.add_argument('--sort', choices=['title', 'runtime'],
+                        help='Sort field')
     args = parser.parse_args()
     moviepath = args.mediapath or os.environ['MEDIAPATH']
     if not moviepath:
@@ -30,7 +47,10 @@ if __name__ == '__main__':
     devices = load_media_dev(moviepath)
     all_movies = compile_movies(devices)
     if args.random:
-        rand_limit = args.random
-        print_movies(random_sample_list(all_movies, rand_limit))
+        chunks = prep_list(random_sample_list(all_movies, args.random))
     else:
-        print_movies(all_movies)
+        chunks = prep_list(all_movies)
+    if args.sort:
+        show_movies(chunks, args.sort)
+    else:
+        show_movies(chunks)

--- a/src/media/tools/movies/show.py
+++ b/src/media/tools/movies/show.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Simple command line client to list out movies'''
 
 # pylint: disable=R0801
@@ -12,16 +35,20 @@ from media.tools.common import (
         )
 
 
-def show_movies(in_list, sort_field=None):
+def show_movies(in_list, in_args):
     '''
     Show every movie entry, ordered by either title or runtime.
     '''
+    sort_field = in_args.sort
+    p_breaks = in_args.pagebreaks
     if sort_field == 'runtime':
         order_list = sorted(in_list, key=lambda x: x.runtime)
     else:
         order_list = sorted(in_list, key=lambda x: x.title_key)
     for movie_out in order_list:
         print(movie_out)
+        if p_breaks:
+            print(chr(12))
 
 
 def prep_list(in_movies):
@@ -40,6 +67,8 @@ if __name__ == '__main__':
     parser.add_argument('--random', type=int, help='print X random entries')
     parser.add_argument('--sort', choices=['title', 'runtime'],
                         help='Sort field')
+    parser.add_argument('--pagebreaks', action=argparse.BooleanOptionalAction,
+                        help='Page break after every movie.')
     args = parser.parse_args()
     moviepath = args.mediapath or os.environ['MEDIAPATH']
     if not moviepath:
@@ -50,7 +79,4 @@ if __name__ == '__main__':
         chunks = prep_list(random_sample_list(all_movies, args.random))
     else:
         chunks = prep_list(all_movies)
-    if args.sort:
-        show_movies(chunks, args.sort)
-    else:
-        show_movies(chunks)
+    show_movies(chunks, args)

--- a/src/media/tools/movies/timebuckets.py
+++ b/src/media/tools/movies/timebuckets.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-List out all movies, one per line.
+List out a breakdown of movie time lengths into buckets.
 '''
 
 # pylint: disable=R0801

--- a/src/media/tools/movies/timebuckets.py
+++ b/src/media/tools/movies/timebuckets.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+'''
+List out all movies, one per line.
+'''
+
+# pylint: disable=R0801
+
+from datetime import timedelta
+
+import os
+import argparse
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
+from media.tools.movies.list import prep_list
+from media.tools.movies.genrebreakdown import proportion_bar
+
+
+class BucketManager():
+    '''
+    Holds all bucket objects, and performs
+    reporting, and data aggregation operations across all of them.
+    '''
+    def __init__(self, in_limit=10):
+        self.limit = in_limit
+        self.buckets = []
+        self.average = None
+        self.median = None
+        self.median_title = ''
+        self.movie_count = 0
+        self.interval = 0
+
+    def initialize_bucket_ranges(self, in_list):
+        '''
+        Set up ever bucket object (up to limit), and
+        configure the range values of each object.
+        '''
+        shortest = in_list[0].runtime
+        longest = in_list[-1].runtime
+        interval = self.get_bucket_interval(shortest, longest)
+        # print(f"Interval is {interval}\n")
+        start_i = shortest
+        for _ in range(1, self.limit + 1):
+            self.buckets.append(Bucket(start_i, interval, len(in_list)))
+            start_i += timedelta(seconds=interval)
+
+    def get_bucket_interval(self, shortest, longest):
+        '''
+        Determine the bucket interval length by subtracting the shortest
+        movie runtime from the longest movie runtime, then divide it
+        by the number of requested buckets.  This requires turning the
+        runtimes into integers that represent all of the seconds in the
+        timedelta object.
+
+        Input is two timedelta objects, and the return value is another
+        timedelta object.
+        '''
+        delta_range = longest - shortest
+        delta_int = int(delta_range.total_seconds())
+        range_int = int(delta_int / self.limit) + 1
+        self.interval = timedelta(seconds=range_int)
+        return range_int
+
+    def install_in_buckets(self, in_list):
+        '''
+        For every passed movie, install it into a bucket by
+        passing it to every bucket object, knowing that
+        it only gets accepted into a single bucket.
+
+        There are probably ways to make this code more
+        efficient.
+        '''
+        total_r = 0
+        for movie_i in in_list:
+            for bucket_i in self.buckets:
+                if bucket_i.is_in_range(movie_i.runtime):
+                    bucket_i.movies.append(movie_i)
+                    break
+            total_r += movie_i.runtime.total_seconds()
+        self.movie_count = len(in_list)
+        self.calculate_average(total_r)
+        self.calculate_median(in_list)
+
+    def calculate_average(self, total_runtimes):
+        '''
+        Caculate the average time of all the movies.
+        '''
+        average_seconds = int(total_runtimes / self.movie_count)
+        self.average = timedelta(seconds=average_seconds)
+
+    def calculate_median(self, in_list):
+        '''
+        Calculate the median time of all the movies, and
+        report on which titles(s) fit the median.
+        '''
+        if self.movie_count % 2 == 0:
+            median1 = int(self.movie_count / 2)
+            median2 = median1 + 1
+            total_median_seconds = in_list[median1].runtime.total_seconds() + \
+                in_list[median2].runtime.total_seconds()
+            self.median = timedelta(seconds=int(total_median_seconds / 2))
+            self.median_title = f"{in_list[median1].movie.title!s:s} / " + \
+                f"{in_list[median2].movie.title!s:s}"
+        else:
+            median1 = int(self.movie_count / 2)
+            self.median = in_list[median1].runtime
+            self.median_title = f"{in_list[median1].movie.title!s:s}"
+
+    def report_buckets(self):
+        '''
+        Generate a report on all buckets, by sending the report command
+        to every bucket in the list.  Then provide summary data
+        at the bottom of the report.
+        '''
+        print(Bucket.header())
+        for bucket_i in self.buckets:
+            print(bucket_i.report())
+        print(Bucket.hdr_lines())
+        print(f"         Movie count : {self.movie_count}")
+        print(f"Average film runtime : {self.average!s:s}")
+        print(f" Median film runtime : {self.median!s:8s} " +
+              f"({self.median_title})")
+        print(f"     Interval Length : {self.interval!s:s}")
+        print(f"        Bucket Count : {len(self.buckets)}")
+
+
+class Bucket():
+    '''
+    A single bucket designed to hold movie objects.
+
+    It has a low end limit and a high end limit, and then uses those
+    timedelta values to see if a movie should go in that bucket
+    based on the length of the movie.
+    '''
+    def __init__(self, in_low_limit, in_range,  in_total_count):
+        self.low_limit = in_low_limit
+        self.high_limit = in_low_limit + timedelta(seconds=in_range)
+        self.total_count = in_total_count
+        self.movies = []
+
+    def is_in_range(self, in_timedelta):
+        '''
+        Simple check to see if a passed movie falls within the bucket
+        range.
+        '''
+        return bool(self.low_limit <= in_timedelta < self.high_limit)
+
+    def range_print(self):
+        '''
+        A debugging method to examine the bucket status.
+        '''
+        return f"Low   : {self.low_limit}\n" + \
+            f"High  : {self.high_limit}\n" + \
+            f"Count : {len(self.movies)} / {self.total_count}\n\n"
+
+    @classmethod
+    def header(cls):
+        '''
+        Sends out a report header.
+        '''
+        out = f"{'Random Title':50s} " + \
+              f"{'From':8s} {'To':8s} " + \
+              f"{'Count':5s} {'Perc':6s} {'Ratio':50s}\n" + \
+              cls.hdr_lines()
+        return out
+
+    @classmethod
+    def hdr_lines(cls):
+        '''
+        Sends out formatting lines used in the report header.
+        '''
+        return f"{'-' * 50} {'-'*8} {'-'*8} {'-'*5} {'-'*6} {'-'*50}"
+
+    def report(self):
+        '''
+        Generate a report entry on a single bucket object.
+        Show the range limits (low and high, the number of
+        movies, the percentage based on a total, and a tick bar
+        for illustrative purposes.  Also show a random movie title.
+        '''
+        tick_bar = proportion_bar(len(self.movies), self.total_count)
+        movie = random_sample_list(self.movies, 1)
+        if len(movie) > 0:
+            mov_title = str(movie[0].movie.title)
+            perc = float(len(self.movies) / self.total_count * 100)
+        else:
+            mov_title = " << None >>"
+            perc = 0
+        return f"{str(mov_title):50s} {self.low_limit!s:>8s} " + \
+               f"{self.high_limit!s:>8s} {len(self.movies):5d} " + \
+               f"{perc:5.1f}% {tick_bar}"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple movie list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--buckets', type=int, help='number of sample buckets')
+    args = parser.parse_args()
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    devices = load_media_dev(mediapath)
+    all_movies = compile_movies(devices)
+    list_entries = prep_list(all_movies)
+    sorted_movies = sorted(list_entries, key=lambda x: x.runtime)
+    if args.buckets:
+        buckets = BucketManager(args.buckets)
+    else:
+        buckets = BucketManager()
+    buckets.initialize_bucket_ranges(sorted_movies)
+    buckets.install_in_buckets(sorted_movies)
+    buckets.report_buckets()

--- a/src/media/tools/movies/validate.py
+++ b/src/media/tools/movies/validate.py
@@ -1,6 +1,29 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
-List out all movies, one per line.
+Run simple validation tests against the movies, report any incomplete data.
 '''
 
 # pylint: disable=R0801

--- a/src/media/tools/movies/validate.py
+++ b/src/media/tools/movies/validate.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+'''
+List out all movies, one per line.
+'''
+
+# pylint: disable=R0801
+# pylint: disable=too-few-public-methods
+
+import os
+import argparse
+from datetime import timedelta
+from media.tools.common import (
+        load_media_dev, compile_movies, random_sample_list
+        )
+
+
+class Status():
+    '''
+    Status object for a given movie.
+
+    It contains the movie object, an array of faults,
+    and a simple flag determining whether or not the
+    film is acceptable.
+    '''
+    def __init__(self, in_movie):
+        self.movie = in_movie
+        self.acceptable = True
+        self.faults = []
+
+    def add_fault(self, in_fault):
+        '''Add a fault object to the movie status'''
+        self.faults.append(in_fault)
+        self.acceptable = False
+
+    def report_faults(self):
+        '''Report faults for a movie if present.'''
+        out = ''
+        if not self.acceptable:
+            fault1 = self.faults.pop(0)
+            out = f"{self.movie.title!s:50s} {fault1!s}\n"
+            for flt in self.faults:
+                out += f"{' ' * 50} {flt!s}\n"
+        return out
+
+    @classmethod
+    def status_header(cls):
+        '''Return a generic output header.'''
+        return f"{'Movie Title':50s} {'Faults'}\n" + \
+               f"{'-' * 50:s} {'-' * 25:s}"
+
+    def __lt__(self, other):
+        return self.movie.unique_key < other.movie.unique_key
+
+    def __gt__(self, other):
+        return self.movie.unique_key > other.movie.unique_key
+
+
+class Fault():
+    '''
+    Fault class, identifying the reason for the fault, and
+    a severity score.
+    '''
+    def __init__(self, in_reason, in_score=5):
+        self.reason = in_reason
+        self.score = in_score
+
+    def __str__(self):
+        return self.reason
+
+
+class Tester():
+    '''
+    Simple tester class that examines the attributes of a movie,
+    and identifies faults if they are present.
+    '''
+
+    @classmethod
+    def test_plot(cls, movie_status):
+        '''Test the movie plot.'''
+        p_string = str(movie_status.movie.story.plot).strip()
+        if not p_string:
+            movie_status.add_fault(Fault("Plot missing"))
+        else:
+            words = p_string.split()
+            pwc = len(words)
+            if pwc < 20:
+                movie_status.add_fault(Fault("Plot has less than 20 words"))
+
+    @classmethod
+    def test_technical(cls, movie_status):
+        '''Test the movie technical data.'''
+        if movie_status.movie.technical:
+            tech = movie_status.movie.technical
+            if tech.runtime:
+                runtime = tech.runtime.overall or timedelta(0)
+                if runtime == timedelta(0):
+                    movie_status.add_fault(Fault("Runtime is undefined"))
+                elif runtime == timedelta(seconds=1, minutes=1, hours=1):
+                    movie_status.add_fault(Fault("Suspicious runtime value"))
+        else:
+            movie_status.add_fault(Fault("Technical block missing"))
+
+    @classmethod
+    def test_catalog(cls, movie_status):
+        '''Test the movie catalog data.'''
+        if movie_status.movie.catalog:
+            mcat = movie_status.movie.catalog
+            if mcat.copyright:
+                if len(mcat.copyright.holders) == 0:
+                    movie_status.add_fault(Fault("No copyright holder info"))
+            else:
+                movie_status.add_fault(Fault("No copyright info"))
+
+
+def validate_movies(in_list):
+    '''
+    Initialize all the movie status objects, and then
+    run through the tests.
+    '''
+    m_status = []
+    for movie in in_list:
+        m_status.append(Status(movie))
+    for movie_s in m_status:
+        Tester.test_plot(movie_s)
+        Tester.test_technical(movie_s)
+        Tester.test_catalog(movie_s)
+    return m_status
+
+
+def report_validation(in_list):
+    '''
+    Report any movie faults if they are present.
+    '''
+    print(Status.status_header())
+    for movie_s in sorted(in_list):
+        if not movie_s.acceptable:
+            print(movie_s.report_faults(), end='\r')
+
+
+def report_stats(all_movies_c, sample_c, in_reports):
+    '''
+    Provide a summary report on all movie faults.
+    '''
+    fault_count = 0
+    for report_i in in_reports:
+        if not report_i.acceptable:
+            fault_count += 1
+    print(f"{'-' * 50} {'-' * 25}")
+    print(f"{'Movie Count :':>25s} {all_movies_c}")
+    print(f"{'Random Sample Size :':>25s} {sample_c} " +
+          f"({sample_c/all_movies_c*100:5.2f}%)")
+    print(f"{'Fault Count :':>25s} {fault_count}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple movie list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    parser.add_argument('--random', type=int, help='print X random entries')
+    parser.add_argument('--stats', action='store_true',
+                        help='report statistics')
+    args = parser.parse_args()
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    devices = load_media_dev(mediapath)
+    all_movies = compile_movies(devices)
+    if args.random:
+        sample = random_sample_list(all_movies, args.random)
+    else:
+        sample = all_movies
+    status_reports = validate_movies(sample)
+    report_validation(status_reports)
+    if args.stats:
+        report_stats(len(all_movies), len(sample), status_reports)

--- a/src/media/xml/__init__.py
+++ b/src/media/xml/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/src/media/xml/functions.py
+++ b/src/media/xml/functions.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''XML Namespace Constants'''
 
 #

--- a/src/media/xml/functions.py
+++ b/src/media/xml/functions.py
@@ -11,3 +11,11 @@ def xs_bool(in_string):
     if in_string in ['true', '1']:
         return True
     return False
+
+
+def xs_text_strip(in_string):
+    '''Strip outer whitespace from a string in an XML element.'''
+    chunk = in_string.strip()
+    if chunk:
+        return chunk
+    return None

--- a/src/media/xml/namespaces.py
+++ b/src/media/xml/namespaces.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''XML Namespace Constants'''
 
 

--- a/src/media/xml/parser.py
+++ b/src/media/xml/parser.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Main parser class for XML files'''
 
 import xml.etree.ElementTree as ET

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/__init__.py
+++ b/test/media/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/__init__.py
+++ b/test/media/data/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/__init__.py
+++ b/test/media/data/media/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/contents/__init__.py
+++ b/test/media/data/media/contents/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/contents/generic/__init__.py
+++ b/test/media/data/media/contents/generic/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/contents/generic/test_catalog.py
+++ b/test/media/data/media/contents/generic/test_catalog.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+'''Unit tests for classification classes.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.media.contents.movie import Movie
+from media.data.media.contents.generic.catalog import (
+        Title, Catalog, Copyright, AlternateTitles,
+        UniqueConstraints
+        )
+
+CASE1 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>A River Turns Inward</title>
+</movie>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>Love And Crime In Sacramento</title>
+ <catalog>
+  <altTitles>
+   <originalTitle>Love And Crime In Bakersfield</originalTitle>
+  </altTitles>
+  <copyright>
+   <year>1972</year>
+   <holders>
+    <holder>A Can Apart Productions, LLC</holder>
+   </holders>
+  </copyright>
+  <ucIndex>
+   <value>2</value>
+   <note>Big Movie Year</note>
+  </ucIndex>
+ </catalog>
+</movie>
+'''
+
+CASE3 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>74 Minutes To Countdown</title>
+ <catalog>
+  <altTitles>
+   <variantTitle
+   sortable='true'>Seventy Four Minutes To Countdown</variantTitle>
+  </altTitles>
+  <copyright>
+   <year>1977</year>
+   <holders>
+    <holder>Sit, Ubuntu, Sit</holder>
+   </holders>
+  </copyright>
+ </catalog>
+</movie>
+'''
+
+
+class TestTitle(unittest.TestCase):
+    '''
+    Generic Title Object
+    '''
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+
+    def test_title_object(self):
+        '''
+        Assert Title instance is created.
+        '''
+        self.assertIsInstance(self.movie.title, Title)
+
+    def test_title_set(self):
+        '''
+        Assert Title instance has correct value.
+        '''
+        self.assertEqual(str(self.movie.title), "A River Turns Inward")
+
+    def test_title_sort_title(self):
+        '''
+        Assert Title instance has correct sort_value.
+        '''
+        self.assertEqual(self.movie.title.sort_title, "river_turns_inward__a")
+
+    def test_title_file_title(self):
+        '''
+        Assert Title instance has correct file_title.
+        '''
+        self.assertEqual(self.movie.title.file_title, "a_river_turns_inward")
+
+
+class TestCatalog(unittest.TestCase):
+    '''
+    Tests Catalog object.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method.
+        '''
+        xmlroot1 = ET.fromstring(CASE2)
+        self.movie = Movie(xmlroot1)
+
+    def test_catalog_object(self):
+        '''
+        Assert Catalog instance is created.
+        '''
+        self.assertIsInstance(self.movie.catalog, Catalog)
+
+    def test_alt_title_object(self):
+        '''
+        Assert AlternateTitles instance is created.
+        '''
+        self.assertIsInstance(self.movie.catalog.alt_titles, AlternateTitles)
+
+    def test_copyright_object(self):
+        '''
+        Assert Copyright instance is created.
+        '''
+        self.assertIsInstance(self.movie.catalog.copyright, Copyright)
+
+    def test_unique_constraints_object(self):
+        '''
+        Assert UniqueConstraints instace is created.
+        '''
+        self.assertIsInstance(self.movie.catalog.unique_index,
+                              UniqueConstraints)
+
+
+class TestCopyright(unittest.TestCase):
+    '''
+    Test Copyright object.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method.
+        '''
+        xmlroot1 = ET.fromstring(CASE2)
+        self.movie = Movie(xmlroot1)
+
+    def test_copyright_year(self):
+        '''
+        Assert Copyright instance has correct year value.
+        '''
+        self.assertEqual(self.movie.catalog.copyright.year, 1972)
+
+    def test_copyright_holders(self):
+        '''
+        Assert Copyright instance has correct holder value.
+        '''
+        self.assertIn("A Can Apart Productions, LLC",
+                      self.movie.catalog.copyright.holders)
+
+
+class TestAlternateTitles(unittest.TestCase):
+    '''
+    Test AlternateTitles object.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method.
+        '''
+        xmlroot1 = ET.fromstring(CASE2)
+        xmlroot2 = ET.fromstring(CASE3)
+        self.catalog1 = Movie(xmlroot1).catalog
+        self.catalog2 = Movie(xmlroot2).catalog
+
+    def test_variant_title(self):
+        '''
+        Assert AlternateTitle/variant_title is properly set.
+        '''
+        self.assertEqual(str(self.catalog2.alt_titles.variant_title),
+                         "Seventy Four Minutes To Countdown")
+
+    def test_original_title(self):
+        '''
+        Assert AlternateTitle/original_title is properly set.
+        '''
+        self.assertEqual(self.catalog1.alt_titles.original_title,
+                         "Love And Crime In Bakersfield")
+
+
+class TestUniqueConstraints(unittest.TestCase):
+    '''
+    Test UniqueConstraints object.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method.
+        '''
+        xmlroot1 = ET.fromstring(CASE2)
+        self.catalog1 = Movie(xmlroot1).catalog
+
+    def test_unique_constraint_index(self):
+        '''
+        Test UniqueConstraint/index value is properly set.
+        '''
+        self.assertEqual(self.catalog1.unique_index.index, 2)
+
+    def test_unique_constraint_note(self):
+        '''
+        Assert UniqueConstraint/note value is properly set.
+        '''
+        self.assertEqual(self.catalog1.unique_index.note, "Big Movie Year")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/media/data/media/contents/generic/test_catalog.py
+++ b/test/media/data/media/contents/generic/test_catalog.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for classification classes.'''
 
 # pylint: disable=R0801

--- a/test/media/data/media/contents/generic/test_keywords.py
+++ b/test/media/data/media/contents/generic/test_keywords.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for keywords classes.'''
 
 import unittest
@@ -17,9 +40,34 @@ CASE1 = '''<?xml version='1.0'?>
    <generic>hotel</generic>
    <properNoun><place><ci>Miami</ci><st>Florida</st></place></properNoun>
    <properNoun><entity>US Army</entity></properNoun>
+   <properNoun><art type='movie' year='1980'>Xanadu</art></properNoun>
   </keywords>
  </story>
 </movie>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<keywords xmlns='http://vectortron.com/xml/media/movie'>
+ <generic>baseball</generic>
+</keywords>
+'''
+
+CASE3 = '''<?xml version='1.0'?>
+<keywords xmlns='http://vectortron.com/xml/media/movie'>
+ <generic> </generic>
+</keywords>
+'''
+
+CASE4 = '''<?xml version='1.0'?>
+<keywords xmlns='http://vectortron.com/xml/media/movie'>
+ <generic> </generic>
+</keywords>
+'''
+
+CASE5 = '''<?xml version='1.0'?>
+<keywords xmlns='http://vectortron.com/xml/media/movie'>
+ <generic/>
+</keywords>
 '''
 
 
@@ -143,3 +191,89 @@ class TestProperNounKeyword(unittest.TestCase):
         '''
         keyword = self.movie.story.keywords.pools['generic'][2]
         self.assertEqual(keyword.detail(), 'properNoun/place/Miami (Florida)')
+
+
+class TestProperNounArtKeyword(unittest.TestCase):
+    """
+    Tests against ProperNoun Art keywords.
+    """
+    def setUp(self):
+        """
+        Test setup method.
+        """
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+
+    def test_propernoun_art_object(self):
+        """
+        Asset object instance is created.
+        """
+        keyword = self.movie.story.keywords.pools['generic'][4]
+        self.assertIsInstance(keyword, ProperNounKeyword)
+
+    def test_propernoun_art_value(self):
+        """
+        Test proper noun art object value.
+        """
+        keyword = self.movie.story.keywords.pools['generic'][4]
+        self.assertEqual(str(keyword), 'Xanadu (movie)')
+
+    def test_propernoun_art_object_detail(self):
+        """
+        Assert object detail value is correct.
+        """
+        keyword = self.movie.story.keywords.pools['generic'][4]
+        self.assertEqual(keyword.detail(), 'properNoun/art/Xanadu (movie)')
+
+
+class TestKeywordObject(unittest.TestCase):
+    """Tests against the keyword object directly"""
+    def setUp(self):
+        """Setup method"""
+        xmlroot1 = ET.fromstring(CASE2)
+        self.keywords = Keywords(xmlroot1)
+
+    def test_keyword_object_instance(self):
+        """Confirm object is properly created"""
+        self.assertIsInstance(self.keywords, Keywords)
+
+    def test_keyword_array_length(self):
+        """Confirm all keywords are counted"""
+        self.assertEqual(len(self.keywords.all()), 1)
+
+
+class TestKeywordInputValidation1(unittest.TestCase):
+    """Tests for input validation of generic keywords"""
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE3)
+        self.keywords = Keywords(xmlroot1)
+
+    def test_no_generic_keyword_from_bad_input1(self):
+        """Confirm whitespace keyword does not create an object"""
+        self.assertEqual(len(self.keywords.all()), 0)
+
+
+class TestKeywordInputValidation2(unittest.TestCase):
+    """Tests for empty generic keyword value"""
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE4)
+        self.keywords = Keywords(xmlroot1)
+
+    def test_no_generic_keyword_from_bad_input2(self):
+        """Confirm empty keyword did not create an object"""
+        self.assertEqual(len(self.keywords.all()), 0)
+
+
+class TestKeywordInputValidation3(unittest.TestCase):
+    """Tests for empty generic keyword value"""
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE5)
+        self.keywords = Keywords(xmlroot1)
+
+    def test_no_generic_keyword_from_bad_input3(self):
+        """Confirm empty keyword did not create an object"""
+        self.assertEqual(len(self.keywords.all()), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/media/data/media/contents/generic/test_keywords.py
+++ b/test/media/data/media/contents/generic/test_keywords.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+'''Unit tests for keywords classes.'''
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.media.contents.movie import Movie
+from media.data.media.contents.generic.keywords import (
+        Keywords, GenericKeyword, ProperNounKeyword
+        )
+
+CASE1 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>Where's The Ardvark?</title>
+ <story>
+  <keywords>
+   <generic>bank robbery</generic>
+   <generic>hotel</generic>
+   <properNoun><place><ci>Miami</ci><st>Florida</st></place></properNoun>
+   <properNoun><entity>US Army</entity></properNoun>
+  </keywords>
+ </story>
+</movie>
+'''
+
+
+class TestKeywords(unittest.TestCase):
+    '''
+    Tests against Keywords class.
+    '''
+    def setUp(self):
+        '''
+        Test Keywords object.
+        '''
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+
+    def test_keywords_object(self):
+        '''
+        Assert Keywords instance is created.
+        '''
+        kws = self.movie.story.keywords
+        self.assertIsInstance(kws, Keywords)
+
+    def test_keywords_contains_group(self):
+        '''
+        Assert generic group is in Keywords instance.
+        '''
+        kws = self.movie.story.keywords
+        self.assertIn('generic', kws.pool_list())
+
+
+class TestGenericKeyword(unittest.TestCase):
+    '''
+    Tests against GenericKeyword class.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method
+        '''
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+
+    def test_generic_object(self):
+        '''
+        Assert GenericKeyword instance is created
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][0]
+        self.assertIsInstance(keyword, GenericKeyword)
+
+    def test_generic_set(self):
+        '''
+        Assert GenericKeyword has a value
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][0]
+        self.assertEqual(str(keyword), 'bank robbery')
+
+    def test_generic_sort_value(self):
+        '''
+        Assert sort_value is properly set.
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][0]
+        self.assertEqual(keyword.sort_value, 'bank robbery')
+
+    def test_generic_object_order(self):
+        '''
+        Assert 2 GenericKeywords can be sort compared
+        '''
+        keyword1 = self.movie.story.keywords.pools['generic'][0]
+        keyword2 = self.movie.story.keywords.pools['generic'][1]
+        self.assertTrue(keyword1 < keyword2)
+
+    def test_generic_object_detail(self):
+        '''
+        Assert GenericKeyword detail value properly set.
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][0]
+        self.assertEqual(keyword.detail(), 'generic/bank robbery')
+
+
+class TestProperNounKeyword(unittest.TestCase):
+    '''
+    Tests against ProperNounKeyword class.
+    '''
+    def setUp(self):
+        '''
+        Test Setup Method
+        '''
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+
+    def test_propernoun_object(self):
+        '''
+        Assert ProperNounKeyword instance is created
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][2]
+        self.assertIsInstance(keyword, ProperNounKeyword)
+
+    def test_propernoun_object_set(self):
+        '''
+        Assert ProperNounKeyword has a value.
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][2]
+        self.assertEqual(str(keyword), 'Miami (Florida)')
+
+    def test_propernoun_sort_value(self):
+        '''
+        Assert sort_value is properly set.
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][2]
+        self.assertTrue(keyword.sort_value, 'miami')
+
+    def test_propernoun_object_order(self):
+        '''
+        Assert ProperNounKeyword can be sort compared.
+        '''
+        keyword1 = self.movie.story.keywords.pools['generic'][2]
+        keyword2 = self.movie.story.keywords.pools['generic'][1]
+        self.assertTrue(keyword2 < keyword1)
+
+    def test_propernoun_object_detail(self):
+        '''
+        Assert ProperNounKeyword detail value.
+        '''
+        keyword = self.movie.story.keywords.pools['generic'][2]
+        self.assertEqual(keyword.detail(), 'properNoun/place/Miami (Florida)')

--- a/test/media/data/media/contents/movie/__init__.py
+++ b/test/media/data/media/contents/movie/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/contents/movie/test_classification.py
+++ b/test/media/data/media/contents/movie/test_classification.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+'''Unit tests for classification classes.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.media.contents.movie.classification import (
+        Classification, Category, Genres
+        )
+
+CASE1 = '''<?xml version='1.0'?>
+<classification xmlns='http://vectortron.com/xml/media/movie'>
+ <category><fiction/></category>
+ <genres>
+  <primary>Comedy</primary>
+  <secondary>Mystery</secondary>
+  <subgenres>
+   <subgenre>based on a book</subgenre>
+  </subgenres>
+ </genres>
+</classification>
+'''
+
+
+class TestClassification(unittest.TestCase):
+    '''
+    Unit tests for main classification class.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.classification = Classification(xmlroot)
+
+    def test_classification_member(self):
+        '''
+        Assert Classification instance is created.
+        '''
+        self.assertIsInstance(self.classification, Classification)
+
+    def test_category_member(self):
+        '''
+        Assert Category instance is created.
+        '''
+        self.assertIsInstance(self.classification.category, Category)
+
+    def test_genres_member(self):
+        '''
+        Assert Genres instance is created.
+        '''
+        self.assertIsInstance(self.classification.genres, Genres)
+
+
+class TestCategory(unittest.TestCase):
+    '''
+    Tests related to Category object.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.classification = Classification(xmlroot)
+
+    def test_category(self):
+        '''
+        Assert Category value returns proper string.
+        '''
+        self.assertEqual(str(self.classification.category), 'FICTION')
+
+
+class TestGenres(unittest.TestCase):
+    '''
+    Tests related to Genre object.
+    '''
+    def setUp(self):
+        xmlroot = ET.fromstring(CASE1)
+        self.classification = Classification(xmlroot)
+
+    def test_primary_genre(self):
+        '''
+        Test that the primary classification has been set.
+        '''
+        self.assertEqual(self.classification.genres.primary, "Comedy")
+
+    def test_secondary_genre1(self):
+        '''
+        Assert that the secondary classification has been set.
+        '''
+        self.assertIn('Mystery', self.classification.genres.secondary)
+
+    def test_subgenre_set(self):
+        '''
+        Assert subgenre value is properly set.
+        '''
+        self.assertIn('based on a book', self.classification.genres.subgenres)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/media/data/media/contents/movie/test_classification.py
+++ b/test/media/data/media/contents/movie/test_classification.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for classification classes.'''
 
 # pylint: disable=R0801

--- a/test/media/data/media/contents/movie/test_internal.py
+++ b/test/media/data/media/contents/movie/test_internal.py
@@ -5,7 +5,7 @@
 
 import unittest
 import xml.etree.ElementTree as ET
-from media.data.media.contents.movie import Movie
+from media.data.media.contents.movie import Movie, MovieException
 
 CASE1 = '''<?xml version='1.0'?>
 <movie xmlns='http://vectortron.com/xml/media/movie'>
@@ -44,6 +44,17 @@ CASE4 = '''<?xml version='1.0'?>
   <ucIndex>
    <value>2</value>
   </ucIndex>
+ </catalog>
+</movie>
+'''
+
+CASE5 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title> </title>
+ <catalog>
+  <copyright>
+   <year>1977</year>
+  </copyright>
  </catalog>
 </movie>
 '''
@@ -130,3 +141,13 @@ class TestMovieVariantTitle(unittest.TestCase):
         Assert sort order between two movies.
         '''
         self.assertTrue(self.movie1 > self.movie2)
+
+
+class TestMovieTitleException(unittest.TestCase):
+    '''Movie title exception'''
+    def test_title_exception(self):
+        '''Text exception with title triggers Movie object exception.'''
+        xmlroot1 = ET.fromstring(CASE5)
+        with self.assertRaises(MovieException):
+            movie1 = Movie(xmlroot1)
+            del movie1

--- a/test/media/data/media/contents/movie/test_internal.py
+++ b/test/media/data/media/contents/movie/test_internal.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+'''Unit tests for classification classes.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.media.contents.movie import Movie
+
+CASE1 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>A River Turns Inward</title>
+</movie>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>Love And Crime In Sacramento</title>
+</movie>
+'''
+
+CASE3 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>Valerie's Mistake, Greg's Terror</title>
+ <catalog>
+  <copyright>
+   <year>1994</year>
+  </copyright>
+ </catalog>
+</movie>
+'''
+
+CASE4 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>74 Minutes To Countdown</title>
+ <catalog>
+  <altTitles>
+   <variantTitle
+    sortable='true'>Seventy Four Minutes To Countdown</variantTitle>
+  </altTitles>
+  <copyright>
+   <year>1977</year>
+  </copyright>
+  <ucIndex>
+   <value>2</value>
+  </ucIndex>
+ </catalog>
+</movie>
+'''
+
+
+class TestMovie(unittest.TestCase):
+    '''
+    Basic movie object tests.
+    '''
+    def setUp(self):
+        '''
+        Setup Test Method.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot)
+
+    def test_movie_instance(self):
+        '''
+        Assert the movie instance is created.
+        '''
+        self.assertIsInstance(self.movie, Movie)
+
+    def test_movie_unique_key(self):
+        '''
+        Assert the unique key value for a given movie.
+        '''
+        self.assertEqual(self.movie.unique_key,
+                         "river_turns_inward__a-0000-1")
+
+
+class TestMovieSort(unittest.TestCase):
+    '''
+    Test for multi-movie object sorting.
+    '''
+    def setUp(self):
+        '''
+        Setup Test Method.
+        '''
+        xmlroot1 = ET.fromstring(CASE1)
+        xmlroot2 = ET.fromstring(CASE2)
+        self.movie1 = Movie(xmlroot1)
+        self.movie2 = Movie(xmlroot2)
+
+    def test_movie_object_order(self):
+        '''
+        Assert the sorting functionality between two Movie objects.
+        '''
+        self.assertTrue(self.movie2 < self.movie1)
+
+
+class TestMoviePunctuationTitle(unittest.TestCase):
+    '''
+    Punctuation title movie tests.
+    '''
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE3)
+        self.movie = Movie(xmlroot1)
+
+    def test_movie_punctuation_unique_key(self):
+        '''
+        Assert unique_key removes punctuation.
+        '''
+        self.assertEqual(self.movie.unique_key,
+                         "valeries_mistake_gregs_terror-1994-1")
+
+
+class TestMovieVariantTitle(unittest.TestCase):
+    '''Variant title movie tests.'''
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE4)
+        xmlroot2 = ET.fromstring(CASE2)
+        self.movie1 = Movie(xmlroot1)
+        self.movie2 = Movie(xmlroot2)
+
+    def test_movie_variant_unique_key(self):
+        '''
+        Assert unique_key against a movie with a variant title.
+        '''
+        self.assertEqual(self.movie1.unique_key,
+                         "seventy_four_minutes_to_countdown-1977-2")
+
+    def test_movie_variant_order(self):
+        '''
+        Assert sort order between two movies.
+        '''
+        self.assertTrue(self.movie1 > self.movie2)

--- a/test/media/data/media/contents/movie/test_internal.py
+++ b/test/media/data/media/contents/movie/test_internal.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for classification classes.'''
 
 # pylint: disable=R0801

--- a/test/media/data/media/medium/__init__.py
+++ b/test/media/data/media/medium/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/test/media/data/media/medium/test_productid.py
+++ b/test/media/data/media/medium/test_productid.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+'''Unit tests for classification classes.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+
+from media.data.media.medium.productid import (
+        ProductId, Barcode, SKU, OtherId
+        )
+from media.xml.namespaces import Namespaces
+
+CASE1 = '''<?xml version='1.0'?>
+<productId xmlns='http://vectortron.com/xml/media/media'>
+ <barcode type='upc'>1234567890</barcode>
+ <sku retailer='abcd'>12341234</sku>
+ <other>
+  <name>Proof Of Purchase</name>
+  <value>1234A</value>
+  <value>1234B</value>
+ </other>
+ <other>
+  <name>Cult Classics Spine Number</name>
+  <value>102</value>
+ </other>
+</productId>
+'''
+
+
+class TestProductId(unittest.TestCase):
+    '''
+    Unit tests covering product identification values.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.product_id = ProductId(xmlroot)
+
+    def test_object_instance(self):
+        '''
+        Assert ProductId object is properly created.
+        '''
+        self.assertIsInstance(self.product_id, ProductId)
+
+
+class TestBarcode(unittest.TestCase):
+    '''
+    Unit tests relating to barcodes.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        barcode_element = xmlroot.findall('./media:barcode', Namespaces.ns)[0]
+        self.barcode = Barcode(barcode_element)
+
+    def test_barcode_object(self):
+        '''
+        Assert Barcode object is created.
+        '''
+        self.assertIsInstance(self.barcode, Barcode)
+
+    def test_barcode_str_value(self):
+        '''
+        Assert Barcode string return value is correct.
+        '''
+        self.assertEqual(str(self.barcode), '1234567890 (upc)')
+
+    def test_barcode_value(self):
+        '''
+        Assert the Barcode internval value is correct.
+        '''
+        self.assertEqual(self.barcode.value, '1234567890')
+
+    def test_barcode_type(self):
+        '''
+        Assert Barcode type value is correct.
+        '''
+        self.assertEqual(self.barcode.type, 'upc')
+
+
+class TestSku(unittest.TestCase):
+    '''
+    Unit tests relating to a retailer SKU value.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        sku_element = xmlroot.findall('./media:sku', Namespaces.ns)[0]
+        self.sku = SKU(sku_element)
+
+    def test_sku_object(self):
+        '''
+        Assert SKU object is created.
+        '''
+        self.assertIsInstance(self.sku, SKU)
+
+    def test_sku_str_value(self):
+        '''
+        Assert SKU object string return value is correct.
+        '''
+        self.assertEqual(str(self.sku), '12341234 (abcd)')
+
+    def test_sku_value(self):
+        '''
+        Asseert the SKU internal value is correct.
+        '''
+        self.assertEqual(self.sku.value, '12341234')
+
+    def test_sku_retailer(self):
+        '''
+        Test retailer attribute.
+        '''
+        self.assertEqual(self.sku.retailer, 'abcd')
+
+
+class TestOther(unittest.TestCase):
+    '''
+    Tests for other measurable/identifiable values on a piece
+    of media.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        others = xmlroot.findall('./media:other', Namespaces.ns)
+        self.other_1 = OtherId(others[0])
+        self.other_2 = OtherId(others[1])
+
+    def test_other_object(self):
+        '''
+        Assert OtherID object exists.
+        '''
+        self.assertIsInstance(self.other_1, OtherId)
+
+    def test_other_object_name(self):
+        '''
+        Assert name value is correct.
+        '''
+        self.assertEqual(self.other_1.name, 'Proof Of Purchase')
+
+    def test_other_object_value_count(self):
+        '''
+        Assert both values are captured.
+        '''
+        self.assertEqual(len(self.other_1.values), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/media/data/media/medium/test_productid.py
+++ b/test/media/data/media/medium/test_productid.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for classification classes.'''
 
 # pylint: disable=R0801

--- a/test/media/data/media/medium/test_release.py
+++ b/test/media/data/media/medium/test_release.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+'''Unit tests for classification classes.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+
+from media.data.media.medium.release import (
+        Release, ReleaseException, FormalType
+        )
+
+
+CASE1 = '''<?xml version='1.0'?>
+<release xmlns='http://vectortron.com/xml/media/media'>
+ <type><bluray/></type>
+ <publisher>Beta Barn</publisher>
+</release>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<release xmlns='http://vectortron.com/xml/media/media'>
+ <type></type>
+</release>
+'''
+
+
+class TestRelease(unittest.TestCase):
+    '''
+    Unit tests covering the product release.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.release = Release(xmlroot)
+
+    def test_object_instance(self):
+        '''
+        Assert Release object is properly created.
+        '''
+        self.assertIsInstance(self.release, Release)
+
+
+class TestReleaseException(unittest.TestCase):
+    '''
+    Unit tests for the release exception conditions.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+
+    def test_release_exception(self):
+        '''
+        Assert that an error will occur if the release
+        type is empty.
+        '''
+        xmlroot = ET.fromstring(CASE2)
+        with self.assertRaises(ReleaseException):
+            release1 = Release(xmlroot)
+            del release1
+
+
+class TestReleaseType(unittest.TestCase):
+    '''
+    Unit tests for the release type value.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.release = Release(xmlroot)
+
+    def test_type_value(self):
+        '''
+        Assert the the product type is set.
+        '''
+        self.assertEqual(self.release.type, 'bluray')
+
+
+class TestReleasePublisher(unittest.TestCase):
+    '''
+    Unit tests for the release publisher value.
+    '''
+    def setUp(self):
+        '''
+        Set up unit tests.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        self.release = Release(xmlroot)
+
+    def test_publisher_value(self):
+        '''
+        Verify the publisher value is set properly.
+        '''
+        self.assertEqual(self.release.publisher, 'Beta Barn')
+
+
+class TestFormalType(unittest.TestCase):
+    '''
+    Unit tests for the FormalType.formal_convert function.
+    '''
+    def test_correct_type_mapping(self):
+        '''
+        Assert that a blu-ray type is properly represented.
+        '''
+        self.assertEqual(FormalType.formal_convert('bluray'), 'Blu-Ray')
+
+    def test_unknown_type_mapping(self):
+        '''
+        Assert that an unknown type gets the UNKNOWN string value.
+        '''
+        self.assertEqual(FormalType.formal_convert('squeezebox'), 'UNKNOWN')

--- a/test/media/data/media/medium/test_release.py
+++ b/test/media/data/media/medium/test_release.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''Unit tests for classification classes.'''
 
 # pylint: disable=R0801

--- a/test/media/data/test_dates.py
+++ b/test/media/data/test_dates.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+'''
+Unit tests against date objects.
+'''
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.dates import ExactDate, RangeDate
+from media.xml.namespaces import Namespaces
+
+CASE1 = '''<?xml version='1.0'?>
+<date xmlns='http://vectortron.com/xml/media/media'>
+<exact>2020-10-30</exact></date>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<date xmlns='http://vectortron.com/xml/media/media'>
+<from>2020-10-30</from><range>P3Y</range></date>
+'''
+
+
+class TestExactDate(unittest.TestCase):
+    '''
+    Test suite for the ExactDate object.
+    '''
+    def setUp(self):
+        '''
+        Test initialization.
+        '''
+        xmlroot = ET.fromstring(CASE1)
+        date_element = xmlroot.findall('./media:exact', Namespaces.ns)[0]
+        self.ed_object = ExactDate(date_element)
+
+    def test_ed_object_initialization(self):
+        '''
+        Make sure date object is created.
+        '''
+        self.assertIsInstance(self.ed_object, ExactDate)
+
+    def test_ed_object_value(self):
+        '''
+        Make sure the date is set correctly.
+        '''
+        self.assertEqual(str(self.ed_object), '2020-10-30')
+
+
+class TestRangeDate(unittest.TestCase):
+    '''
+    First test suite for the RangeDate object.
+    '''
+    def setUp(self):
+        '''
+        Test initialization.
+        '''
+        xmlroot = ET.fromstring(CASE2)
+        start_element = xmlroot.findall('./media:from', Namespaces.ns)[0]
+        range_element = xmlroot.findall('./media:range', Namespaces.ns)[0]
+        self.rd_object = RangeDate(start_element, range_element)
+
+    def test_rd_object_initialization(self):
+        '''
+        Make sure date object is created.
+        '''
+        self.assertIsInstance(self.rd_object, RangeDate)
+
+    def test_rd_object_from_date(self):
+        '''
+        Confirm start date is set.
+        '''
+        self.assertEqual(self.rd_object.date, '2020-10-30')
+
+    def test_rd_object_range_interval(self):
+        '''
+        Confirm range interval is set.
+        '''
+        self.assertEqual(self.rd_object.end, 'P3Y')
+
+    def test_rd_object_full_string(self):
+        '''
+        Confirm full text string.
+        '''
+        self.assertEqual(str(self.rd_object), '2020-10-30 -> P3Y')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/media/data/test_dates.py
+++ b/test/media/data/test_dates.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 '''
 Unit tests against date objects.
 '''

--- a/test/media/data/test_nouns.py
+++ b/test/media/data/test_nouns.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""Unit tests against proper noun objects.
+"""
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.data.nouns import Name
+
+CASE1 = '''<?xml version='1.0'?>
+<name xmlns='http://vectortron.com/xml/media/movie'>
+ <gn>Patrick</gn><fn>Swayze</fn>
+</name>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<name xmlns='http://vectortron.com/xml/media/movie'>
+ <gn>Barbara</gn><fn>Stanwick</fn>
+</name>
+'''
+
+CASE3 = '''<?xml version='1.0'?>
+<name xmlns='http://vectortron.com/xml/media/movie'>
+ <gn>Jack</gn>
+</name>
+'''
+
+
+class TestProperNounName(unittest.TestCase):
+    """Test suite for Name (set 1)
+    """
+    def setUp(self):
+        """Test initialization."""
+        xmlroot = ET.fromstring(CASE1)
+        self.name = Name(xmlroot)
+
+    def test_name_member(self):
+        """Assert name instance is created."""
+        self.assertIsInstance(self.name, Name)
+
+    def test_name_value(self):
+        """Assert name returns proper string."""
+        self.assertEqual(str(self.name), 'Patrick Swayze')
+
+
+class TestProperNounNameSorting(unittest.TestCase):
+    """Test suite for Name sorting.
+    """
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE1)
+        xmlroot2 = ET.fromstring(CASE2)
+        xmlroot3 = ET.fromstring(CASE3)
+        self.name1 = Name(xmlroot1)
+        self.name2 = Name(xmlroot2)
+        self.name3 = Name(xmlroot3)
+
+    def test_regular_name_sort(self):
+        """Compare sorting of two regular names.
+        """
+        self.assertTrue(self.name1 > self.name2)
+
+    def test_special_name_sort(self):
+        """Compare sort between full name and given name.
+        """
+        self.assertTrue(self.name3 < self.name1)
+
+    def test_special_name_sort_value(self):
+        """Verify sort_value value."""
+        self.assertEqual(self.name3.sort_value, 'jack')
+
+    def test_name_sort_value(self):
+        """Verify sort value for regular name."""
+        self.assertEqual(self.name1.sort_value, 'swayze_patrick')


### PR DESCRIPTION
Milestone: 0.1.5

Accumulated changes:

 - [medialibrary-72](https://github.com/cjcodeproj/medialibrary/issues/72) Prep work for first release to PyPi (0.1.5)
 - [medialibrary-50](https://github.com/cjcodeproj/medialibrary/issues/50) More metadata in the pyproject.toml
 - [medialibrary-65](https://github.com/cjcodeproj/medialibrary/issues/65) All code files should have copyright headers
 - [medialibrary-68](https://github.com/cjcodeproj/medialibrary/issues/68) Command line tool genrebreakdown has same bad title dictionary index
 - [medialibrary-67](https://github.com/cjcodeproj/medialibrary/issues/67) Page break between movie entries
 - [medialibrary-66](https://github.com/cjcodeproj/medialibrary/issues/66) POC tool castlist doesn't handle duplicate titles properly
 - [medialibrary-46](https://github.com/cjcodeproj/medialibrary/issues/46) Command line tools should have stats option
 - [medialibrary-63](https://github.com/cjcodeproj/medialibrary/issues/63) Create object code to handle "art" proper noun
 - [medialibrary-62](https://github.com/cjcodeproj/medialibrary/issues/62) First PyPi test
 - [medialibrary-56](https://github.com/cjcodeproj/medialibrary/issues/56) File loader ignored Blu-Ray 3d movies
 - [medialibrary-45](https://github.com/cjcodeproj/medialibrary/issues/45) XML elements without text may cause an error when stripped
 - [medialibrary-18](https://github.com/cjcodeproj/medialibrary/issues/18) Proper Noun name sorting mixes up when there is no family name
