### PR TITLE
Integration to Main (Release 0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 medialibrary CHANGELOG
 ======================
 
+## CURRENT
+ - [medialibrary-149](https://github.com/cjcodeproj/medialibrary/issues/149) TitleMunger could provide directory path inforamtion
+ - [medialibrary-150](https://github.com/cjcodeproj/medialibrary/issues/150) Add the xlink and xml namespaces
+ - [medialibrary-145](https://github.com/cjcodeproj/medialibrary/issues/145) Derivative content title objects may benefit from refactoring
+ - [medialibrary-80](https://github.com/cjcodeproj/medialibrary/issues/80) Comparator framework
+ - [medialibrary-144](https://github.com/cjcodeproj/medialibrary/issues/144) Base class for all content objects
+ - [medialibrary-140](https://github.com/cjcodeproj/medialibrary/issues/140) Output a catalog title
+`
 ## RELEASE 0.2.1
  - [medialibrary-125](https://github.com/cjcodeproj/medialibrary/issues/125) Create simple example documentation
  - [medialibrary-127](https://github.com/cjcodeproj/medialibrary/issues/127) Consider deprecating random_sample_list()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 medialibrary CHANGELOG
 ======================
 
-## CURRENT
+## RELEASE 0.2.3
+ - [medialibrary-162](https://github.com/cjcodeproj/medialibrary/issues/162) Release 0.2.3
  - [medialibrary-149](https://github.com/cjcodeproj/medialibrary/issues/149) TitleMunger could provide directory path inforamtion
  - [medialibrary-150](https://github.com/cjcodeproj/medialibrary/issues/150) Add the xlink and xml namespaces
  - [medialibrary-145](https://github.com/cjcodeproj/medialibrary/issues/145) Derivative content title objects may benefit from refactoring
  - [medialibrary-80](https://github.com/cjcodeproj/medialibrary/issues/80) Comparator framework
  - [medialibrary-144](https://github.com/cjcodeproj/medialibrary/issues/144) Base class for all content objects
  - [medialibrary-140](https://github.com/cjcodeproj/medialibrary/issues/140) Output a catalog title
-`
+
 ## RELEASE 0.2.1
  - [medialibrary-125](https://github.com/cjcodeproj/medialibrary/issues/125) Create simple example documentation
  - [medialibrary-127](https://github.com/cjcodeproj/medialibrary/issues/127) Consider deprecating random_sample_list()

--- a/doc/tools/movies/compare.rst
+++ b/doc/tools/movies/compare.rst
@@ -1,0 +1,110 @@
+=======================
+media.tools.movies.compare
+=======================
+
+NAME
+----
+
+media.tools.movies.compare - compare movies in a repository against each other
+
+SYNOPSIS
+--------
+
+::
+
+  $ python -m media.tools.movies.compare [-h] [--mediapath MEDIAPATH]
+
+DESCRIPTION
+-----------
+
+Provides a summary of movies in a repository, with details on the story, keywords, the cast and crew involved.
+
+OPTIONS
+-------
+
+``--mediapath``
+    Path to scan for media files
+
+EXAMPLES
+--------
+
+Example 1: Comparison operation::
+
+  $ python -m media.tools.movies.compare
+
+  ...
+  Source Movie: White Sands (1992)
+  =========================================================================================
+  Movie                               Matches Score Trait              Value
+  ----------------------------------- ------- ----- ------------------ --------------------
+  A Time To Kill (1996)                     3    17 Cinemaphotographer Peter Menzies Jr.
+                                                    Cast               Samuel L. Jackson
+                                                    Cast               Beth Grant
+  The Dark Wind (1991)                      2    13 Keyword            desert
+                                                    Keyword            New Mexico
+  Iron Man 2 (2010)                         2    10 Cast               Mickey Rourke
+                                                    Cast               Samuel L. Jackson
+  Pat Garrett & Billy The Kid (1973)        1     8 Keyword            New Mexico
+  The Guilt Trip (2012)                     1     8 Keyword            New Mexico
+  The Sum Of All Fears (2002)               1     8 Writer             Daniel Pyne
+  Shooter (2007)                            1     7 Cinemaphotographer Peter Menzies Jr.
+  Hard Rain (1998)                          1     7 Cinemaphotographer Peter Menzies Jr.
+  Outrageous Fortune (1987)                 1     5 Keyword            desert
+  Electra Glide In Blue (1973)              1     5 Keyword            desert
+  8 Seconds (1994)                          1     5 Cast               James Rebhorn
+  2 Guns (2013)                             1     5 Keyword            undercover
+  Harper Valley P.T.A. (1978)               1     5 Cast               Royce D. Applegate
+  Body Heat (1981)                          1     5 Cast               Mickey Rourke
+  Burglar (1987)                            1     5 Keyword            briefcase
+  Blood Simple (1983)                       1     5 Cast               M. Emmet Walsh
+  Breakdown (1997)                          1     5 Keyword            desert
+  Far From Home (1989)                      1     5 Keyword            desert
+  Fool For Love (1985)                      1     5 Keyword            desert
+  The Last Ride (2004)                      1     5 Keyword            undercover
+  The Last Ride (1994)                      1     5 Cast               Mickey Rourke
+  Lost Highway (1996)                       1     5 Cast               Jack Kehler
+  Red Rock West (1992)                      1     5 Keyword            desert
+  Raw Courage (1984)                        1     5 Cast               M. Emmet Walsh
+  The Rainmaker (1997)                      1     5 Cast               Mickey Rourke
+  Another Stakeout (1993)                   1     5 Keyword            undercover
+  The Adventures Of Priscilla, Queen        1     5 Keyword            desert
+  The Kill Room (2023)                      1     5 Cast               Samuel L. Jackson
+  Knives Out (2019)                         1     5 Cast               M. Emmet Walsh
+  Consenting Adults (1992)                  1     5 Cast               Mary Elizabeth Mastrantonio
+  Carlito's Way (1993)                      1     5 Cast               James Rebhorn
+  Inglorious Basterds (2009)                1     5 Cast               Samuel L. Jackson
+  The Wizard (1989)                         1     5 Cast               Beth Grant
+  Waterworld (1995)                         1     5 Cast               Jack Kehler
+  The Wraith (1986)                         1     5 Keyword            desert
+  Pulp Fiction (1994)                       1     5 Keyword            briefcase
+  The Professionals (1966)                  1     5 Keyword            desert
+  True Romance (1993)                       1     5 Cast               Samuel L. Jackson
+  Goldstone (2016)                          1     5 Keyword            desert
+  The Game (1997)                           1     5 Cast               James Rebhorn
+  Grandview, U.S.A. (1984)                  1     5 Cast               M. Emmet Walsh
+  Scarface (1983)                           1     5 Cast               Mary Elizabeth Mastrantonio
+  Speed (1994)                              1     5 Cast               Beth Grant
+  Steel Dawn (1987)                         1     5 Keyword            desert
+  Stakeout (1987)                           1     5 Keyword            undercover
+  Sunset (1988)                             1     5 Cast               M. Emmet Walsh
+  Incredibles 2 (2018)                      1     5 Cast               Samuel L. Jackson
+  Dune (2021)                               1     5 Keyword            desert
+  Tremors (1990)                            1     5 Keyword            desert
+  John Wick: Chapter 3 - Parabellum         1     5 Keyword            desert
+  Avengers: Endgame (2019)                  1     5 Cast               Samuel L. Jackson
+  Captain America: The First Avenger        1     5 Cast               Samuel L. Jackson
+  The Avengers (2012)                       1     5 Cast               Samuel L. Jackson
+  ...
+
+
+
+ENVIRONMENT VARIABLES
+---------------------
+
+``MEDIAPATH``
+    The default path to the media repository if it isn't defined on the command line.
+
+SEE ALSO
+--------
+
+media.tools.movies.list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "medialibrary"
-version = "0.2.1"
-description = "Library for reading vtmedia XML files"
+version = "0.2.3"
+description = "Package for reading vtmedia XML files describing a movie/music media library"
 readme = "README.md"
 requires-python = ">3.8"
 license = {text = "MIT License"}
-keywords = ["xml", "movies", "dvds"]
+keywords = ["xml", "movies", "dvds", "music"]
 authors = [
   {email = "cjcodeproj@fastmail.com", name = "Chris J"}
 ]
@@ -16,7 +16,10 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Topic :: Text Processing :: Markup :: XML"
+  "Topic :: Text Processing :: Markup :: XML",
+  "Topic :: Multimedia",
+  "Topic :: Multimedia :: Sound/Audio",
+  "Topic :: Multimedia :: Video"
 ]
 
 [project.urls]

--- a/src/media/data/media/contents/internal.py
+++ b/src/media/data/media/contents/internal.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+'''
+Abstract object classes used by all content objects.
+'''
+
+# pylint: disable=too-few-public-methods
+
+from media.xml.namespaces import Namespaces
+from media.data.media.contents.generic.catalog import (
+        Title, TitleValueException, Catalog
+        )
+from media.generic.titletools import TitleMunger
+
+
+class AbstractContent():
+    '''
+    Abstract class for all content, working under the
+    assumption that any content object will have a
+    title and a catalog.
+    '''
+    def __init__(self):
+        self.title = None
+        self.catalog = None
+        self.sort_title = ""
+        self.unique_key = ""
+
+    def _process(self, in_element):
+        for child in in_element:
+            tagname = Namespaces.ns_strip(child.tag)
+            if tagname == 'title':
+                try:
+                    self.title = Title(child.text)
+                except TitleValueException as tve:
+                    raise ContentException(tve.message) from tve
+            if tagname == 'catalog':
+                self.catalog = Catalog(child)
+
+    def _post_load_process(self):
+        if self.title:
+            self._build_unique_key()
+
+    def _build_unique_key(self):
+        self.sort_title = TitleMunger.build_sort_cat_title(
+                self.title, self.catalog)
+        self.unique_key = TitleMunger.build_unique_key_string(
+                self.title, self.catalog)
+
+    def catalog_title(self):
+        '''
+        Return a formatted title that inclues the copyright year.
+        '''
+        return TitleMunger.build_catalog_title(
+                self.title, self.catalog)
+
+
+class ContentException(Exception):
+    '''
+    Root class for all content related exceptions.
+    '''
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/src/media/data/media/contents/movie/internal.py
+++ b/src/media/data/media/contents/movie/internal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2023 Chris Josephes
+# Copyright 2024 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,9 +29,7 @@
 
 from datetime import timedelta
 from media.xml.namespaces import Namespaces
-from media.data.media.contents.generic.catalog import (
-        Title, TitleValueException, Catalog
-        )
+from media.data.media.contents import AbstractContent, ContentException
 from media.data.media.contents.generic.story import Story
 from media.data.media.contents.genericv.crew import Crew
 from media.data.media.contents.genericv.technical import Technical
@@ -39,16 +37,13 @@ from media.data.media.contents.movie.classification import Classification
 from media.generic.sorting.lists import ContentIndex
 
 
-class Movie():
+class Movie(AbstractContent):
     '''Movie object'''
-    def __init__(self, in_chunk):
-        self.title = None
-        self.catalog = None
+    def __init__(self, in_element):
+        super().__init__()
         self.technical = None
         self.crew = None
-        self.sort_title = ""
-        self.unique_key = ""
-        self._process(in_chunk)
+        self._process(in_element)
 
     def build_index_object(self):
         """
@@ -57,15 +52,9 @@ class Movie():
         """
         return MovieIndexEntry(self)
 
-    def _process(self, in_chunk):
-        for child in in_chunk:
-            if child.tag == Namespaces.nsf('movie') + 'title':
-                try:
-                    self.title = Title(child.text)
-                except TitleValueException as tve:
-                    raise MovieException(tve.message) from tve
-            if child.tag == Namespaces.nsf('movie') + 'catalog':
-                self.catalog = Catalog(child)
+    def _process(self, in_element):
+        super()._process(in_element)
+        for child in in_element:
             if child.tag == Namespaces.nsf('movie') + 'classification':
                 self.classification = Classification(child)
             if child.tag == Namespaces.nsf('movie') + 'technical':
@@ -76,33 +65,7 @@ class Movie():
                 self.story = Story(child)
             if child.tag == Namespaces.nsf('movie') + 'crew':
                 self.crew = Crew(child)
-        if self.title is not None:
-            self._build_unique_key()
-
-    def _build_unique_key(self):
-        ukv = None
-        cpy = None
-        if self.catalog is not None:
-            if self.catalog.alt_titles is not None:
-                if self.catalog.alt_titles.variant_sort is True:
-                    self.sort_title = \
-                            self.catalog.alt_titles.variant_title.sort_title
-                    self.unique_key = self.sort_title
-                else:
-                    self.sort_title = self.title.sort_title
-                    self.unique_key = self.sort_title
-            if self.catalog.copyright is not None:
-                cpy = str(self.catalog.copyright.year)
-            else:
-                cpy = "0000"
-            if self.catalog.unique_index is not None:
-                ukv = str(self.catalog.unique_index.index)
-            else:
-                ukv = "1"
-            self.unique_key += "-" + cpy + "-" + ukv
-        else:
-            self.sort_title = self.title.sort_title
-            self.unique_key = self.sort_title + "-0000-1"
+        self._post_load_process()
 
     def __hash__(self):
         return hash(self.unique_key)
@@ -157,7 +120,7 @@ class MovieIndexEntry(ContentIndex):
         self.first_letter = self.sort_title[0]
 
 
-class MovieException(Exception):
+class MovieException(ContentException):
     '''Exception raised when there is an issue with a movie.'''
     def __init__(self, message):
         super().__init__(message)

--- a/src/media/generic/compare/__init__.py
+++ b/src/media/generic/compare/__init__.py
@@ -21,9 +21,3 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-
-'''
-Placeholder for all abstract content object imports.
-'''
-
-from .internal import *

--- a/src/media/generic/compare/movie.py
+++ b/src/media/generic/compare/movie.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2023 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+
+'''
+Comparison classes that check two movies against each other.
+'''
+
+# pylint: disable=too-few-public-methods
+
+
+from media.data.media.contents.generic.keywords import ProperNounKeyword
+
+
+class MovieComparator():
+    '''
+    Loads all films, and creates individual comparison
+    operation objects for each film, allowing each
+    film to maintain a separate object for scoring
+    data and comparison operations.
+    '''
+    def __init__(self):
+        self.data = []
+        self.results = []
+
+    def load_data(self, in_list):
+        '''
+        Load all films into the object array.
+        '''
+        self.data.extend(in_list)
+
+    def compare(self):
+        '''
+        Build the comparator objects, and then
+        have very object run the comparison
+        operation against all of the films.
+        '''
+        for film in self.data:
+            self.results.append(MovieComparison(film))
+        for film_compare in self.results:
+            for film in self.data:
+                film_compare.compare_against(film)
+
+    def report(self):
+        '''
+        Generate output reports for a given film.
+        '''
+        for result in self.results:
+            result.report()
+
+
+class MovieComparison():
+    '''
+    Object class for running comparison operations of
+    any film against an internally stored film.
+    '''
+    def __init__(self, in_film):
+        self.film = in_film
+        self.matches = {}
+
+    def compare_against(self, in_film):
+        '''
+        Compare the passed film against the film stored in the object.
+
+        Do not run if the film passed is identical to the interal film.
+
+        All comparison operations are literally just tests between
+        'self' and 'other', similar to object comparator methods.
+        '''
+        if in_film == self.film:
+            return
+        self.compare_director(in_film)
+        self.compare_writer(in_film)
+        self.compare_cinemaphotographer(in_film)
+        self.compare_editor(in_film)
+        self.compare_cast(in_film)
+        self.compare_keywords(in_film)
+
+    def add_match(self, in_film, in_trait):
+        '''
+        If a match is identified, add it to the internal data structure.
+        '''
+        other_f = in_film
+        if other_f not in self.matches:
+            self.matches[other_f] = MovieMatch(other_f, in_trait)
+        else:
+            self.matches[other_f].add_trait(in_trait)
+
+    def compare_director(self, in_film):
+        '''
+        See if the other film has identical directors.
+        '''
+        for director in in_film.crew.directors:
+            if director in self.film.crew.directors:
+                self.add_match(in_film, MatchTrait('Director', director, 10))
+
+    def compare_writer(self, in_film):
+        '''
+        See if the other film has identical writers.
+        '''
+        for writer in in_film.crew.writers:
+            if writer in self.film.crew.writers:
+                self.add_match(in_film, MatchTrait('Writer', writer, 8))
+
+    def compare_cinemaphotographer(self, in_film):
+        '''
+        See if the other film has identical cinemaphotographers.
+        '''
+        for cinema in in_film.crew.cinemap:
+            if cinema in self.film.crew.cinemap:
+                trait = MatchTrait('Cinemaphotographer', cinema, 7)
+                self.add_match(in_film, trait)
+
+    def compare_editor(self, in_film):
+        '''
+        See if the other film has similar directors.
+        '''
+        for editor in in_film.crew.editors:
+            if editor in self.film.crew.editors:
+                self.add_match(in_film, MatchTrait('Editor', editor, 6))
+
+    def compare_cast(self, in_film):
+        '''
+        See if the other filn has similar actors.
+        '''
+        in_cast = in_film.crew.cast
+        my_cast = self.film.crew.cast
+        if in_cast and my_cast:
+            for role in in_cast.cast:
+                other_actor = role.actor
+                for mrole in my_cast.cast:
+                    m_actor = mrole.actor
+                    if other_actor == m_actor:
+                        self.add_match(in_film, MatchTrait('Cast', m_actor, 5))
+
+    def compare_keywords(self, in_film):
+        '''
+        See if the other film has identical keywords.
+        '''
+        other_keywords = in_film.story.keywords
+        keywords = self.film.story.keywords
+        if other_keywords and keywords:
+            for keyword in other_keywords.all():
+                if keyword in keywords.all():
+                    if isinstance(keyword, ProperNounKeyword):
+                        kw_score = 5 + keyword.relevance
+                    else:
+                        kw_score = 2 + keyword.relevance
+                    trait = MatchTrait('Keyword', keyword, kw_score)
+                    self.add_match(in_film, trait)
+
+    def header(self):
+        '''
+        Report header.
+        '''
+        out = f"\nSource Movie: {self.film.catalog_title()}\n" +\
+              f"{'='*89}\n" +\
+              f"{'Movie':35s} {'Matches':7s} " +\
+              f"{'Score':5s} {'Trait':18s} {'Value':s}\n" +\
+              f"{'-'*35} {'-'*7} {'-'*5} {'-'*18} {'-'*20}\n"
+        return out
+
+    def report(self):
+        '''
+        Generate output of comparison results.
+        '''
+        print(self.header(), end='')
+        for other_f in sorted(self.matches,
+                              key=lambda x: self.matches[x].points,
+                              reverse=True):
+            print(str(self.matches[other_f]), end='')
+
+
+class MovieMatch():
+    '''
+    Object to keep track of identified matches for a given film.
+    Keeps a copy of the data that matches, and a passed scoring
+    value identifying the quality of the match.
+    '''
+    def __init__(self, in_film, in_trait):
+        self.film = in_film
+        self.traits = [in_trait]
+        self.points = in_trait.score
+
+    def add_trait(self, in_trait):
+        '''
+        If another match has been identified for the same film,
+        then record it.
+        '''
+        self.traits.append(in_trait)
+        self.points += in_trait.score
+
+    def __str__(self):
+        out = ""
+        count = 1
+        trait_count = len(self.traits)
+        for trt in self.traits:
+            if count == 1:
+                out += f"{self.film.catalog_title():34.34s}  " +\
+                       f"{trait_count:7d} {self.points:5d} " +\
+                       f"{trt}\n"
+            else:
+                out += f"{' '*49} {trt}\n"
+            count += 1
+        return out
+
+
+class MatchTrait():
+    '''
+    Simple data structure containing a film, the
+    matching data, and the score value.
+    '''
+    def __init__(self, in_title, in_data, in_score=1):
+        self.title = in_title
+        self.data = in_data
+        self.score = in_score
+
+    def __str__(self):
+        return f"{self.title:18s} {str(self.data)}"

--- a/src/media/generic/language.py
+++ b/src/media/generic/language.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2023 Chris Josephes
+# Copyright 2024 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +22,11 @@
 # SOFTWARE.
 #
 
-'''
-Placeholder for all abstract content object imports.
-'''
+'''Common code related to sorting operations.'''
 
-from .internal import *
+# pylint: disable=too-few-public-methods
+
+
+class LanguageHelpers():
+    '''Static data on languages.'''
+    Articles_English = ['a', 'an', 'the']

--- a/src/media/generic/stringtools.py
+++ b/src/media/generic/stringtools.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2022 Chris Josephes
+# Copyright 2024 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,9 +24,8 @@
 
 '''Common code related to sorting operations.'''
 
-# pylint: disable=too-few-public-methods
-
 import string
+from media.generic.language import LanguageHelpers
 
 
 def transform_string(in_value):
@@ -57,8 +56,3 @@ def build_sort_string(in_value):
         article = word_split.pop(0)
         word_split.append('+'+article)
     return '_'.join(word_split)
-
-
-class LanguageHelpers():
-    '''Static data on languages.'''
-    Articles_English = ['a', 'an', 'the']

--- a/src/media/generic/titletools.py
+++ b/src/media/generic/titletools.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+'''Common code related to manipulating titles.'''
+
+from media.generic.stringtools import transform_string, build_sort_string
+from media.generic.language import LanguageHelpers
+
+
+class TitleMunger():
+    '''
+    Munge title strings into usable data
+
+    Works off of a passed title object, not a raw string.
+    '''
+
+    @classmethod
+    def build_filename_string(cls, in_title):
+        '''
+        Build a string suitable for a filename.
+
+        Ex: The Ugly Brige 2 becomes the_ugly_bridge_2
+        '''
+        level1 = transform_string(str(in_title))
+        return level1.translate(level1.maketrans(" \t\n\r", "____"))
+
+    @classmethod
+    def build_sort_title_string(cls, in_title):
+        '''
+        Create a sortable string based on the title.
+
+        Ex: "The Ugly Bridge 2" becomes "ugly_bridge_2_+the"
+        '''
+        return build_sort_string(str(in_title))
+
+    @classmethod
+    def _chk_cat_sort_title(cls, in_catalog):
+        if in_catalog:
+            if in_catalog.alt_titles:
+                if in_catalog.alt_titles.variant_sort is True:
+                    return str(in_catalog.alt_titles.variant_title)
+        return None
+
+    @classmethod
+    def build_sort_cat_title(cls, in_title, in_catalog):
+        '''
+        Create a sortable string based in the title
+        and catalog info.
+
+        Ex: "9 Ugly Bridges" becomes "nine_ugly_bridges"
+        '''
+        working = TitleMunger._chk_cat_sort_title(in_catalog) or str(in_title)
+        return build_sort_string(working)
+
+    @classmethod
+    def build_unique_key_string(cls, in_title, in_catalog):
+        '''
+        Creates a unique string for the content based on
+        title and catalog info.
+
+        Ex: "The Ugly Bridge 2" becomes "ugly_bridge_2_+the-2023-01"
+        '''
+        level1 = TitleMunger.build_sort_cat_title(str(in_title), in_catalog)
+        year = '0000'
+        idx = '1'
+        if in_catalog:
+            if in_catalog.copyright:
+                if in_catalog.copyright.year:
+                    year = str(in_catalog.copyright.year)
+            if in_catalog.unique_index:
+                idx = f"{in_catalog.unique_index.index:d}"
+        return level1 + '-' + year + '-' + idx
+
+    @classmethod
+    def build_title_path(cls, in_title):
+        '''
+        Create a path string based on a title,
+
+        Ex: "The 3 Ugly Bridges" becomes "3/3us"
+        '''
+        level1 = transform_string(str(in_title))
+        word_split = level1.split()
+        if word_split[0] in LanguageHelpers.Articles_English:
+            word_split.pop(0)
+        first_letter = word_split[0][0]
+        second_letter = word_split[0][1]
+        last_letter = word_split[-1][-1]
+        path_string = f"/{first_letter}/" + \
+                      f"{first_letter}{second_letter}{last_letter}/"
+        return path_string
+
+    @classmethod
+    def build_catalog_title(cls, in_title, in_catalog):
+        '''
+        Creates a title value suitable for reference notation.
+
+        Ex: "The Ugly Bridge 2" becomes "The Ugly Bridge 2 (2023)"
+        '''
+        year = '0000'
+        idx = 1
+        if in_catalog:
+            if in_catalog.copyright:
+                if in_catalog.copyright.year:
+                    year = str(in_catalog.copyright.year)
+            if in_catalog.unique_index:
+                idx = in_catalog.unique_index.index
+        if idx == 1:
+            return f"{in_title!s} ({year})"
+        return f"{in_title!s} ({year}/{idx})"

--- a/src/media/tools/movies/compare.py
+++ b/src/media/tools/movies/compare.py
@@ -23,7 +23,26 @@
 #
 
 '''
-Placeholder for all abstract content object imports.
+Compare all of the movies against each other.
 '''
 
-from .internal import *
+# pylint: disable=R0801
+
+import os
+import argparse
+from media.generic.compare.movie import MovieComparator
+from media.tools.common import load_movies
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple movie list.')
+    parser.add_argument('--mediapath', help='path of media library')
+    args = parser.parse_args()
+    mediapath = args.mediapath or os.environ['MEDIAPATH']
+    if not mediapath:
+        parser.print_help()
+    all_movies = load_movies(mediapath)
+    comparator = MovieComparator()
+    comparator.load_data(all_movies)
+    comparator.compare()
+    comparator.report()

--- a/src/media/xml/namespaces.py
+++ b/src/media/xml/namespaces.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2023 Chris Josephes
+# Copyright 2024 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +28,11 @@
 class Namespaces():
     '''Static data on XML Namespaces'''
     ns = {
-            "media": "http://vectortron.com/xml/media/media",
-            "movie": "http://vectortron.com/xml/media/movie",
-            "authorship": "http://vectortron.com/xml/media/meta/authorship"
+            'media': 'http://vectortron.com/xml/media/media',
+            'movie': 'http://vectortron.com/xml/media/movie',
+            'authorship': 'http://vectortron.com/xml/media/meta/authorship',
+            'xml': 'http://www.w3.org/XML/1998/namespace',
+            'xlink': 'http://www.w3.org/1999/xlink'
         }
 
     @classmethod

--- a/test/media/data/media/contents/movie/test_internal.py
+++ b/test/media/data/media/contents/movie/test_internal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2022 Chris Josephes
+# Copyright 2023 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,8 @@
 
 import unittest
 import xml.etree.ElementTree as ET
-from media.data.media.contents.movie import Movie, MovieException
+from media.data.media.contents.movie import Movie
+from media.data.media.contents import ContentException
 
 CASE1 = '''<?xml version='1.0'?>
 <movie xmlns='http://vectortron.com/xml/media/movie'>
@@ -169,8 +170,8 @@ class TestMovieVariantTitle(unittest.TestCase):
 class TestMovieTitleException(unittest.TestCase):
     '''Movie title exception'''
     def test_title_exception(self):
-        '''Text exception with title triggers Movie object exception.'''
+        '''Test exception with title triggers Content object exception.'''
         xmlroot1 = ET.fromstring(CASE5)
-        with self.assertRaises(MovieException):
+        with self.assertRaises(ContentException):
             movie1 = Movie(xmlroot1)
             del movie1

--- a/test/media/generic/__init__.py
+++ b/test/media/generic/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2023 Chris Josephes
+# Copyright 2024 Chris Josephes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,9 +21,3 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-
-'''
-Placeholder for all abstract content object imports.
-'''
-
-from .internal import *

--- a/test/media/generic/test_titletools.py
+++ b/test/media/generic/test_titletools.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Chris Josephes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+'''Unit tests for code handling titles.'''
+
+# pylint: disable=R0801
+
+import unittest
+import xml.etree.ElementTree as ET
+from media.generic.titletools import TitleMunger
+from media.data.media.contents.movie import Movie
+
+
+CASE1 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>The Awkward Boss</title>
+ <catalog>
+  <copyright>
+   <year>1972</year>
+  </copyright>
+ </catalog>
+</movie>
+'''
+
+CASE2 = '''<?xml version='1.0'?>
+<movie xmlns='http://vectortron.com/xml/media/movie'>
+ <title>9 Scary Ghosts</title>
+ <catalog>
+  <altTitles>
+   <variantTitle sortable='true'>Nine Scary Ghosts</variantTitle>
+  </altTitles>
+  <copyright>
+   <year>1984</year>
+  </copyright>
+  <ucIndex>
+   <value>2</value>
+  </ucIndex>
+ </catalog>
+</movie>
+'''
+
+
+class TestTitleMunger(unittest.TestCase):
+    '''
+    Testing the class methods of the TitleMunger object
+    '''
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE1)
+        self.movie = Movie(xmlroot1)
+        self.title = self.movie.title
+        self.catalog = self.movie.catalog
+
+    def test_catalog_title(self):
+        '''
+        Make sure catalog title is correct
+        '''
+        tm_string = TitleMunger.build_catalog_title(self.title, self.catalog)
+        self.assertEqual(tm_string, 'The Awkward Boss (1972)')
+
+    def test_build_filename_string(self):
+        '''
+        Make sure the code makes a proper filename.
+        '''
+        tm_file_string = TitleMunger.build_filename_string(self.title)
+        self.assertEqual(tm_file_string, 'the_awkward_boss')
+
+    def test_build_sort_string(self):
+        '''
+        Make sure a sort string is properly made.
+        '''
+        tm_sort_string = TitleMunger.build_sort_title_string(self.title)
+        self.assertEqual(tm_sort_string, 'awkward_boss_+the')
+
+    def test_build_unique_key(self):
+        '''
+        Make sure the unique key value is correct.
+        '''
+        tm_key_string = TitleMunger.build_unique_key_string(
+                self.title, self.catalog)
+        self.assertEqual(tm_key_string, 'awkward_boss_+the-1972-1')
+
+    def test_build_title_path(self):
+        '''
+        Make sure the title path is correct.
+        '''
+        tm_path_string = TitleMunger.build_title_path(self.title)
+        self.assertEqual(tm_path_string, '/a/aws/')
+
+
+class TestTitleMungerComplex(unittest.TestCase):
+    '''
+    More tests of the munger against a more complex title.
+    '''
+
+    def setUp(self):
+        xmlroot1 = ET.fromstring(CASE2)
+        self.movie = Movie(xmlroot1)
+        self.title = self.movie.title
+        self.catalog = self.movie.catalog
+
+    def test_build_sort_variant_string(self):
+        '''
+        Get a sort value using the variant string.
+        '''
+        tm_sort_string = TitleMunger.build_sort_cat_title(
+                self.title, self.catalog)
+        self.assertEqual(tm_sort_string, 'nine_scary_ghosts')
+
+    def test_build_unique_key_with_index(self):
+        '''
+        Test a unique key value with a ucIndex value.
+        '''
+        tm_key_string = TitleMunger.build_unique_key_string(
+                self.title, self.catalog)
+        self.assertEqual(tm_key_string, 'nine_scary_ghosts-1984-2')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Release ticket: https://github.com/cjcodeproj/medialibrary/issues/162

Changes:

 - [medialibrary-162](https://github.com/cjcodeproj/medialibrary/issues/162) Release 0.2.3
 - [medialibrary-149](https://github.com/cjcodeproj/medialibrary/issues/149) TitleMunger could provide directory path inforamtion
 - [medialibrary-150](https://github.com/cjcodeproj/medialibrary/issues/150) Add the xlink and xml namespaces
 - [medialibrary-145](https://github.com/cjcodeproj/medialibrary/issues/145) Derivative content title objects may benefit from refactoring
 - [medialibrary-80](https://github.com/cjcodeproj/medialibrary/issues/80) Comparator framework
 - [medialibrary-144](https://github.com/cjcodeproj/medialibrary/issues/144) Base class for all content objects
 - [medialibrary-140](https://github.com/cjcodeproj/medialibrary/issues/140) Output a catalog title
